### PR TITLE
Reduce ethers surface area

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The settings are described in more detailed in the Sequence Web SDK documentatio
     // limits the digital assets displayed on the assets summary screen
     displayedAssets: [
       {
-        contractAddress: ethers.ZeroAddress,
+        contractAddress: zeroAddress,
         chainId: 137,
       },
       {

--- a/examples/react/src/components/Connected.tsx
+++ b/examples/react/src/components/Connected.tsx
@@ -346,7 +346,7 @@ export const Connected = () => {
     }
 
     // NATIVE token sale
-    // const currencyAddress = ethers.ZeroAddress
+    // const currencyAddress = zeroAddress
     // const salesContractAddress = '0xf0056139095224f4eec53c578ab4de1e227b9597'
     // const collectionAddress = '0x92473261f2c26f2264429c451f70b0192f858795'
     // const price = '200000000000000'

--- a/packages/react-checkout/src/hooks/useERC1155SaleContractCheckout.ts
+++ b/packages/react-checkout/src/hooks/useERC1155SaleContractCheckout.ts
@@ -1,7 +1,6 @@
 import { CheckoutOptionsSalesContractArgs, TransactionSwapProvider } from '@0xsequence/marketplace'
 import { findSupportedNetwork } from '@0xsequence/network'
-import { ethers } from 'ethers'
-import { Abi, Hex, encodeFunctionData, toHex } from 'viem'
+import { Abi, Hex, encodeFunctionData, toHex, zeroAddress } from 'viem'
 import { useReadContract, useReadContracts } from 'wagmi'
 
 import { ERC_1155_SALE_CONTRACT } from '../constants/abi'
@@ -26,7 +25,7 @@ type SaleContractSettings = Omit<
 export const getERC1155SaleContractConfig = ({
   chain,
   price,
-  currencyAddress = ethers.ZeroAddress,
+  currencyAddress = zeroAddress,
   recipientAddress,
   collectibles,
   collectionAddress,

--- a/packages/react-checkout/src/utils/sardine.ts
+++ b/packages/react-checkout/src/utils/sardine.ts
@@ -1,6 +1,6 @@
 import { ChainId, networks } from '@0xsequence/network'
 import { DEBUG } from '@0xsequence/react-connect'
-import { ethers } from 'ethers'
+import { zeroAddress } from 'viem'
 
 export interface CheckSardineWhitelistStatusArgs {
   chainId: number
@@ -36,7 +36,7 @@ export const checkSardineWhitelistStatus = async (
         name: 'whitelist-check',
         imageUrl: 'https://www.sequence.market/images/placeholder.png',
         network: networks[chainId as ChainId].name,
-        recipientAddress: ethers.ZeroAddress,
+        recipientAddress: zeroAddress,
         contractAddress: marketplaceAddress,
         platform: 'calldata_execution',
         executionType: 'smart_contract',

--- a/packages/react-checkout/src/views/CheckoutSelection/component/OrderSummaryItem.tsx
+++ b/packages/react-checkout/src/views/CheckoutSelection/component/OrderSummaryItem.tsx
@@ -1,7 +1,8 @@
 import { Card, Image, Text, Skeleton, TokenImage, NetworkImage } from '@0xsequence/design-system'
 import { formatDisplay } from '@0xsequence/react-connect'
 import { useGetTokenMetadata, useGetContractInfo } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
+import { formatUnits } from 'viem'
+
 interface OrderSummaryItem {
   contractAddress: string
   tokenId: string
@@ -29,7 +30,7 @@ export const OrderSummaryItem = ({ contractAddress, tokenId, quantityRaw, chainI
 
   const { logoURI: collectionLogoURI, name: collectionName = 'Unknown Collection' } = contractInfo || {}
 
-  const balanceFormatted = ethers.formatUnits(quantityRaw, decimals)
+  const balanceFormatted = formatUnits(BigInt(quantityRaw), decimals)
 
   return (
     <Card className="flex flex-row items-start justify-between">

--- a/packages/react-checkout/src/views/CheckoutSelection/index.tsx
+++ b/packages/react-checkout/src/views/CheckoutSelection/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@0xsequence/design-system'
 import { ContractVerificationStatus, getNativeTokenInfoByChainId, compareAddress, formatDisplay } from '@0xsequence/react-connect'
 import { useGetTokenBalancesSummary, useGetContractInfo } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
+import { zeroAddress, formatUnits } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
 import { HEADER_HEIGHT } from '../../constants'
@@ -46,7 +46,7 @@ export const CheckoutSelection = () => {
 
   const isPending = (isPendingContractInfo || isPendingBalances) && cryptoCheckoutSettings
 
-  const isNativeToken = compareAddress(cryptoCheckoutSettings?.coinQuantity?.contractAddress || '', ethers.ZeroAddress)
+  const isNativeToken = compareAddress(cryptoCheckoutSettings?.coinQuantity?.contractAddress || '', zeroAddress)
   const nativeTokenInfo = getNativeTokenInfoByChainId(cryptoCheckoutSettings?.chainId || 1, chains)
 
   const coinDecimals = isNativeToken ? nativeTokenInfo.decimals : contractInfoData?.decimals || 0
@@ -57,8 +57,8 @@ export const CheckoutSelection = () => {
   )
   const userBalanceRaw = coinBalance ? coinBalance.balance : '0'
   const requestedAmountRaw = cryptoCheckoutSettings?.coinQuantity?.amountRequiredRaw || '0'
-  const userBalance = ethers.formatUnits(userBalanceRaw, coinDecimals)
-  const requestAmount = ethers.formatUnits(requestedAmountRaw, coinDecimals)
+  const userBalance = formatUnits(BigInt(userBalanceRaw), coinDecimals)
+  const requestAmount = formatUnits(BigInt(requestedAmountRaw), coinDecimals)
   const isInsufficientBalance = BigInt(userBalanceRaw) < BigInt(requestedAmountRaw)
 
   const orderSummaryItems = settings?.orderSummaryItems || []

--- a/packages/react-connect/README.md
+++ b/packages/react-connect/README.md
@@ -242,7 +242,7 @@ The settings are described in more detailed in the Sequence Web SDK documentatio
     // limits the digital assets displayed on the assets summary screen
     displayedAssets: [
       {
-        contractAddress: ethers.ZeroAddress,
+        contractAddress: zeroAddress,
         chainId: 137,
       },
       {

--- a/packages/react-connect/src/components/TxnDetails/TxnDetails.tsx
+++ b/packages/react-connect/src/components/TxnDetails/TxnDetails.tsx
@@ -2,8 +2,8 @@ import { commons } from '@0xsequence/core'
 import { Card, GradientAvatar, Skeleton, Text, TokenImage } from '@0xsequence/design-system'
 import { ContractType, ContractVerificationStatus } from '@0xsequence/indexer'
 import { useAPIClient, useGetTokenBalancesSummary, useGetTokenMetadata } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
 import { useEffect, useState } from 'react'
+import { formatUnits, zeroAddress } from 'viem'
 import { useConfig } from 'wagmi'
 
 import { compareAddress, capitalize, truncateAtMiddle } from '../../utils/helpers'
@@ -88,7 +88,7 @@ const TransferItemInfo = ({ address, transferProps, chainId }: TransferItemInfoP
   const { chains } = useConfig()
   const contractAddress = transferProps.contractAddress
   const toAddress: string | undefined = transferProps.to
-  const isNativeCoin = contractAddress ? compareAddress(contractAddress, ethers.ZeroAddress) : true
+  const isNativeCoin = contractAddress ? compareAddress(contractAddress, zeroAddress) : true
   const is1155 = transferProps.contractType === ContractType.ERC1155
   const isNFT = transferProps.contractType === ContractType.ERC1155 || transferProps.contractType === ContractType.ERC721
   const nativeTokenInfo = getNativeTokenInfoByChainId(chainId, chains)
@@ -147,7 +147,7 @@ const TransferItemInfo = ({ address, transferProps, chainId }: TransferItemInfoP
             </div>
 
             <Text color="muted" variant="normal">
-              {`${ethers.formatUnits(amountSending, is1155 ? tokenMetadata?.[0]?.decimals : isNFT ? 0 : decimals)} ${symbol} `}
+              {`${formatUnits(BigInt(amountSending), is1155 ? tokenMetadata?.[0]?.decimals || 0 : isNFT ? 0 : decimals)} ${symbol} `}
             </Text>
           </div>
         </div>

--- a/packages/react-connect/src/connectors/wagmiConnectors/sequenceWaasConnector.ts
+++ b/packages/react-connect/src/connectors/wagmiConnectors/sequenceWaasConnector.ts
@@ -15,7 +15,8 @@ import {
   TransactionRejectedRpcError,
   UserRejectedRequestError,
   getAddress,
-  zeroAddress
+  zeroAddress,
+  toHex
 } from 'viem'
 import { createConnector } from 'wagmi'
 
@@ -202,7 +203,7 @@ export function sequenceWaasWallet(params: BaseSequenceWaasConnectorOptions) {
 
       await provider.request({
         method: 'wallet_switchEthereumChain',
-        params: [{ chainId: ethers.toQuantity(chainId) }]
+        params: [{ chainId: toHex(chainId) }]
       })
 
       config.emitter.emit('change', { chainId })
@@ -270,7 +271,7 @@ export class SequenceWaasProvider extends ethers.AbstractProvider implements EIP
     }
 
     if (method === 'eth_chainId') {
-      return ethers.toQuantity(this.currentNetwork.chainId)
+      return toHex(this.currentNetwork.chainId)
     }
 
     if (method === 'eth_accounts') {

--- a/packages/react-wallet/src/components/CoinRow.tsx
+++ b/packages/react-wallet/src/components/CoinRow.tsx
@@ -1,7 +1,7 @@
 import { Skeleton, Text, TokenImage } from '@0xsequence/design-system'
 import { formatDisplay } from '@0xsequence/react-connect'
-import { ethers } from 'ethers'
 import React from 'react'
+import { formatUnits } from 'viem'
 
 import { getPercentageColor } from '../utils'
 
@@ -34,7 +34,7 @@ export const CoinRowSkeleton = () => {
 }
 
 export const CoinRow = ({ imageUrl, name, decimals, balance, symbol, fiatValue, priceChangePercentage }: CoinRowProps) => {
-  const formattedBalance = ethers.formatUnits(balance, decimals)
+  const formattedBalance = formatUnits(BigInt(balance), decimals)
   const balanceDisplayed = formatDisplay(formattedBalance)
 
   return (

--- a/packages/react-wallet/src/components/SendItemInfo.tsx
+++ b/packages/react-wallet/src/components/SendItemInfo.tsx
@@ -1,7 +1,7 @@
 import { NetworkImage, Skeleton, Text, TokenImage } from '@0xsequence/design-system'
 import { formatDisplay } from '@0xsequence/react-connect'
-import { ethers } from 'ethers'
 import React from 'react'
+import { formatUnits } from 'viem'
 
 import { useSettings } from '../hooks'
 
@@ -49,7 +49,7 @@ export const SendItemInfo = ({
   balanceSuffix = 'available'
 }: SendItemInfoProps) => {
   const { fiatCurrency } = useSettings()
-  const formattedBalance = ethers.formatUnits(balance, decimals)
+  const formattedBalance = formatUnits(BigInt(balance), decimals)
   const balanceDisplayed = formatDisplay(formattedBalance)
 
   return (

--- a/packages/react-wallet/src/components/TransactionHistoryList/TransactionHistoryItem.tsx
+++ b/packages/react-wallet/src/components/TransactionHistoryList/TransactionHistoryItem.tsx
@@ -4,8 +4,8 @@ import { Transaction, TxnTransfer, TxnTransferType } from '@0xsequence/indexer'
 import { compareAddress, formatDisplay, getNativeTokenInfoByChainId } from '@0xsequence/react-connect'
 import { useGetCoinPrices, useGetExchangeRate } from '@0xsequence/react-hooks'
 import dayjs from 'dayjs'
-import { ethers } from 'ethers'
 import React from 'react'
+import { formatUnits, zeroAddress } from 'viem'
 import { useConfig } from 'wagmi'
 
 import { useSettings, useNavigation } from '../../hooks'
@@ -134,7 +134,7 @@ export const TransactionHistoryItem = ({ transaction }: TransactionHistoryItemPr
         </div>
         {amounts.map((amount, index) => {
           const nativeTokenInfo = getNativeTokenInfoByChainId(transaction.chainId, chains)
-          const isNativeToken = compareAddress(transfer.contractAddress, ethers.ZeroAddress)
+          const isNativeToken = compareAddress(transfer.contractAddress, zeroAddress)
           const isCollectible = transfer.contractInfo?.type === 'ERC721' || transfer.contractInfo?.type === 'ERC1155'
           let decimals
           const tokenId = transfer.tokenIds?.[index]
@@ -143,7 +143,7 @@ export const TransactionHistoryItem = ({ transaction }: TransactionHistoryItemPr
           } else {
             decimals = isNativeToken ? nativeTokenInfo.decimals : transfer.contractInfo?.decimals
           }
-          const amountValue = ethers.formatUnits(amount, decimals)
+          const amountValue = formatUnits(BigInt(amount), decimals || 18)
           const symbol = isNativeToken ? nativeTokenInfo.symbol : transfer.contractInfo?.symbol || ''
           const tokenLogoUri = isNativeToken ? nativeTokenInfo.logoURI : transfer.contractInfo?.logoURI
 

--- a/packages/react-wallet/src/utils/tokens.ts
+++ b/packages/react-wallet/src/utils/tokens.ts
@@ -2,7 +2,7 @@ import { TokenPrice } from '@0xsequence/api'
 import { TokenBalance, GetTransactionHistoryReturn, Transaction } from '@0xsequence/indexer'
 import { compareAddress } from '@0xsequence/react-connect'
 import { InfiniteData } from '@tanstack/react-query'
-import { ethers } from 'ethers'
+import { formatUnits, zeroAddress } from 'viem'
 
 export const getPercentageColor = (value: number) => {
   if (value > 0) {
@@ -39,7 +39,7 @@ export const computeBalanceFiat = ({ balance, prices, decimals, conversionRate }
     return '0.00'
   }
   const priceFiat = priceForToken.price?.value || 0
-  const valueFormatted = ethers.formatUnits(balance.balance, decimals)
+  const valueFormatted = formatUnits(BigInt(balance.balance), decimals)
   const usdValue = parseFloat(valueFormatted) * priceFiat
   totalUsd += usdValue
 
@@ -65,7 +65,7 @@ export const sortBalancesByType = (balances: TokenBalance[]): SortBalancesByType
 
   balances.forEach(balance => {
     // Note: contractType for the native token should be "UNKNOWN"
-    if (balance.contractAddress === ethers.ZeroAddress) {
+    if (balance.contractAddress === zeroAddress) {
       nativeTokens.push(balance)
     } else if (balance.contractType === 'ERC20') {
       erc20Tokens.push(balance)

--- a/packages/react-wallet/src/views/CoinDetails/index.tsx
+++ b/packages/react-wallet/src/views/CoinDetails/index.tsx
@@ -6,7 +6,7 @@ import {
   useGetExchangeRate,
   useGetTransactionHistory
 } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
+import { formatUnits, zeroAddress } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
 import { InfiniteScroll } from '../../components/InfiniteScroll'
@@ -57,7 +57,7 @@ export const CoinDetails = ({ contractAddress, chainId }: CoinDetailsProps) => {
 
   const dataCoinBalance =
     tokenBalance && tokenBalance.length > 0
-      ? compareAddress(contractAddress, ethers.ZeroAddress)
+      ? compareAddress(contractAddress, zeroAddress)
         ? tokenBalance?.[0]
         : tokenBalance?.[1]
       : undefined
@@ -77,12 +77,12 @@ export const CoinDetails = ({ contractAddress, chainId }: CoinDetailsProps) => {
     return <CoinDetailsSkeleton chainId={chainId} isReadOnly={isReadOnly} />
   }
 
-  const isNativeToken = compareAddress(contractAddress, ethers.ZeroAddress)
+  const isNativeToken = compareAddress(contractAddress, zeroAddress)
   const logo = isNativeToken ? getNativeTokenInfoByChainId(chainId, chains).logoURI : dataCoinBalance?.contractInfo?.logoURI
   const symbol = isNativeToken ? getNativeTokenInfoByChainId(chainId, chains).symbol : dataCoinBalance?.contractInfo?.symbol
   const name = isNativeToken ? getNativeTokenInfoByChainId(chainId, chains).name : dataCoinBalance?.contractInfo?.name
   const decimals = isNativeToken ? getNativeTokenInfoByChainId(chainId, chains).decimals : dataCoinBalance?.contractInfo?.decimals
-  const formattedBalance = ethers.formatUnits(dataCoinBalance?.balance || '0', decimals)
+  const formattedBalance = formatUnits(BigInt(dataCoinBalance?.balance || '0'), decimals || 18)
   const balanceDisplayed = formatDisplay(formattedBalance)
 
   const coinBalanceFiat = dataCoinBalance

--- a/packages/react-wallet/src/views/CollectibleDetails/index.tsx
+++ b/packages/react-wallet/src/views/CollectibleDetails/index.tsx
@@ -6,7 +6,7 @@ import {
   useGetCollectiblePrices,
   useGetExchangeRate
 } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
+import { formatUnits } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
 import { CollectibleTileImage } from '../../components/CollectibleTileImage'
@@ -93,7 +93,7 @@ export const CollectibleDetails = ({ contractAddress, chainId, tokenId }: Collec
 
   const decimals = dataCollectibleBalance?.tokenMetadata?.decimals || 0
   const rawBalance = dataCollectibleBalance?.balance || '0'
-  const balance = ethers.formatUnits(rawBalance, decimals)
+  const balance = formatUnits(BigInt(rawBalance), decimals)
   const formattedBalance = formatDisplay(Number(balance))
 
   const valueFiat = dataCollectibleBalance

--- a/packages/react-wallet/src/views/CollectionDetails/index.tsx
+++ b/packages/react-wallet/src/views/CollectionDetails/index.tsx
@@ -2,7 +2,7 @@ import { Image, Text, TokenImage } from '@0xsequence/design-system'
 import { TokenBalance } from '@0xsequence/indexer'
 import { formatDisplay, ContractVerificationStatus } from '@0xsequence/react-connect'
 import { useGetTokenBalancesDetails } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
+import { formatUnits } from 'viem'
 import { useAccount } from 'wagmi'
 
 import { NetworkBadge } from '../../components/NetworkBadge'
@@ -71,7 +71,7 @@ export const CollectionDetails = ({ chainId, contractAddress }: CollectionDetail
           {collectionBalanceData?.map((balance, index) => {
             const unformattedBalance = balance.balance
             const decimals = balance?.tokenMetadata?.decimals || 0
-            const formattedBalance = formatDisplay(ethers.formatUnits(unformattedBalance, decimals))
+            const formattedBalance = formatDisplay(formatUnits(BigInt(unformattedBalance), decimals))
 
             return (
               <div className="select-none cursor-pointer" key={index} onClick={() => onClickItem(balance)}>

--- a/packages/react-wallet/src/views/Home/components/AssetSummary/CoinTile/index.tsx
+++ b/packages/react-wallet/src/views/Home/components/AssetSummary/CoinTile/index.tsx
@@ -1,13 +1,14 @@
 import { TokenBalance } from '@0xsequence/indexer'
 import { compareAddress, formatDisplay, getNativeTokenInfoByChainId } from '@0xsequence/react-connect'
 import { useGetContractInfo, useGetCoinPrices, useGetExchangeRate } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
+import { formatUnits, zeroAddress } from 'viem'
 import { useConfig } from 'wagmi'
 
 import { useSettings } from '../../../../../hooks'
 import { computeBalanceFiat, getPercentagePriceChange } from '../../../../../utils'
 
 import { CoinTileContent } from './CoinTileContent'
+
 interface CoinTileProps {
   balance: TokenBalance
 }
@@ -15,7 +16,7 @@ interface CoinTileProps {
 export const CoinTile = ({ balance }: CoinTileProps) => {
   const { chains } = useConfig()
   const { fiatCurrency } = useSettings()
-  const isNativeToken = compareAddress(balance.contractAddress, ethers.ZeroAddress)
+  const isNativeToken = compareAddress(balance.contractAddress, zeroAddress)
   const nativeTokenInfo = getNativeTokenInfoByChainId(balance.chainId, chains)
 
   const { data: dataCoinPrices = [], isPending: isPendingCoinPrice } = useGetCoinPrices([
@@ -45,7 +46,7 @@ export const CoinTile = ({ balance }: CoinTileProps) => {
       decimals: nativeTokenInfo.decimals
     })
     const priceChangePercentage = getPercentagePriceChange(balance, dataCoinPrices)
-    const formattedBalance = ethers.formatUnits(balance.balance, nativeTokenInfo.decimals)
+    const formattedBalance = formatUnits(BigInt(balance.balance), nativeTokenInfo.decimals)
     const balanceDisplayed = formatDisplay(formattedBalance)
 
     return (
@@ -71,7 +72,7 @@ export const CoinTile = ({ balance }: CoinTileProps) => {
   })
   const priceChangePercentage = getPercentagePriceChange(balance, dataCoinPrices)
 
-  const formattedBalance = ethers.formatUnits(balance.balance, decimals)
+  const formattedBalance = formatUnits(BigInt(balance.balance), decimals)
   const balanceDisplayed = formatDisplay(formattedBalance)
 
   const name = contractInfo?.name || 'Unknown'

--- a/packages/react-wallet/src/views/Search/SearchWallet.tsx
+++ b/packages/react-wallet/src/views/Search/SearchWallet.tsx
@@ -1,9 +1,9 @@
 import { SearchIcon, Skeleton, Text, TextInput } from '@0xsequence/design-system'
 import { getNativeTokenInfoByChainId, ContractVerificationStatus, compareAddress } from '@0xsequence/react-connect'
 import { useGetTokenBalancesSummary, useGetCoinPrices, useGetExchangeRate } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
 import Fuse from 'fuse.js'
 import { useState } from 'react'
+import { zeroAddress } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
 import { useSettings } from '../../hooks'
@@ -28,7 +28,7 @@ export const SearchWallet = () => {
   })
 
   const coinBalancesUnordered =
-    tokenBalancesData?.filter(b => b.contractType === 'ERC20' || compareAddress(b.contractAddress, ethers.ZeroAddress)) || []
+    tokenBalancesData?.filter(b => b.contractType === 'ERC20' || compareAddress(b.contractAddress, zeroAddress)) || []
 
   const { data: coinPrices = [], isPending: isPendingCoinPrices } = useGetCoinPrices(
     coinBalancesUnordered.map(token => ({
@@ -80,7 +80,7 @@ export const SearchWallet = () => {
   })
 
   const indexedCoinBalances: IndexedData[] = coinBalances.map((balance, index) => {
-    if (compareAddress(balance.contractAddress, ethers.ZeroAddress)) {
+    if (compareAddress(balance.contractAddress, zeroAddress)) {
       const nativeTokenInfo = getNativeTokenInfoByChainId(balance.chainId, chains)
 
       return {

--- a/packages/react-wallet/src/views/Search/SearchWalletViewAll.tsx
+++ b/packages/react-wallet/src/views/Search/SearchWalletViewAll.tsx
@@ -1,9 +1,9 @@
 import { SearchIcon, Skeleton, TabsContent, TabsHeader, TabsRoot, TextInput } from '@0xsequence/design-system'
 import { getNativeTokenInfoByChainId, ContractVerificationStatus, compareAddress } from '@0xsequence/react-connect'
 import { useGetTokenBalancesSummary, useGetCoinPrices, useGetExchangeRate } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
 import Fuse from 'fuse.js'
 import { useState, useEffect } from 'react'
+import { zeroAddress } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
 import { useSettings } from '../../hooks'
@@ -55,7 +55,7 @@ export const SearchWalletViewAll = ({ defaultTab }: SearchWalletViewAllProps) =>
   })
 
   const coinBalancesUnordered =
-    tokenBalancesData?.filter(b => b.contractType === 'ERC20' || compareAddress(b.contractAddress, ethers.ZeroAddress)) || []
+    tokenBalancesData?.filter(b => b.contractType === 'ERC20' || compareAddress(b.contractAddress, zeroAddress)) || []
 
   const { data: coinPrices = [], isPending: isPendingCoinPrices } = useGetCoinPrices(
     coinBalancesUnordered.map(token => ({
@@ -95,7 +95,7 @@ export const SearchWalletViewAll = ({ defaultTab }: SearchWalletViewAllProps) =>
   const isPending = isPendingTokenBalances || isPendingCoinPrices || isPendingConversionRate
 
   const indexedCoinBalances: IndexedData[] = coinBalances.map((balance, index) => {
-    if (compareAddress(balance.contractAddress, ethers.ZeroAddress)) {
+    if (compareAddress(balance.contractAddress, zeroAddress)) {
       const nativeTokenInfo = getNativeTokenInfoByChainId(balance.chainId, chains)
 
       return {

--- a/packages/react-wallet/src/views/Search/components/BalanceItem.tsx
+++ b/packages/react-wallet/src/views/Search/components/BalanceItem.tsx
@@ -1,8 +1,8 @@
 import { Text, ChevronRightIcon, TokenImage } from '@0xsequence/design-system'
 import { TokenBalance } from '@0xsequence/indexer'
 import { compareAddress, formatDisplay, getNativeTokenInfoByChainId } from '@0xsequence/react-connect'
-import { ethers } from 'ethers'
 import React from 'react'
+import { formatUnits, zeroAddress } from 'viem'
 import { useConfig } from 'wagmi'
 
 import { useNavigation } from '../../../hooks'
@@ -14,7 +14,7 @@ interface BalanceItemProps {
 export const BalanceItem = ({ balance }: BalanceItemProps) => {
   const { chains } = useConfig()
   const { setNavigation } = useNavigation()
-  const isNativeToken = compareAddress(balance.contractAddress, ethers.ZeroAddress)
+  const isNativeToken = compareAddress(balance.contractAddress, zeroAddress)
   const nativeTokenInfo = getNativeTokenInfoByChainId(balance.chainId, chains)
   const logoURI = isNativeToken ? nativeTokenInfo.logoURI : balance?.contractInfo?.logoURI
   const tokenName = isNativeToken ? nativeTokenInfo.name : balance?.contractInfo?.name || 'Unknown'
@@ -25,7 +25,7 @@ export const BalanceItem = ({ balance }: BalanceItemProps) => {
       return balance.uniqueCollectibles
     }
     const decimals = isNativeToken ? nativeTokenInfo.decimals : balance?.contractInfo?.decimals
-    const bal = ethers.formatUnits(balance.balance, decimals || 0)
+    const bal = formatUnits(BigInt(balance.balance), decimals || 0)
     const displayBalance = formatDisplay(bal)
     const symbol = isNativeToken ? nativeTokenInfo.symbol : balance?.contractInfo?.symbol
 

--- a/packages/react-wallet/src/views/SendCollectible.tsx
+++ b/packages/react-wallet/src/views/SendCollectible.tsx
@@ -24,6 +24,7 @@ import {
 import { useGetTokenBalancesDetails } from '@0xsequence/react-hooks'
 import { ethers } from 'ethers'
 import { useRef, useState, ChangeEvent, useEffect } from 'react'
+import { formatUnits, parseUnits, toHex } from 'viem'
 import { useAccount, useChainId, useSwitchChain, useConfig, useSendTransaction } from 'wagmi'
 
 import { SendItemInfo } from '../components/SendItemInfo'
@@ -92,7 +93,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
         setAmount('1')
         setShowAmountControls(false)
       } else if (contractType === 'ERC1155') {
-        if (Number(ethers.formatUnits(tokenBalance?.balance || 0, decimals)) >= 1) {
+        if (Number(formatUnits(BigInt(tokenBalance?.balance || 0), decimals)) >= 1) {
           setAmount('1')
         }
         setShowAmountControls(true)
@@ -122,7 +123,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
   const name = tokenBalance?.tokenMetadata?.name || 'Unknown'
   const imageUrl = tokenBalance?.tokenMetadata?.image || tokenBalance?.contractInfo?.logoURI || ''
   const amountToSendFormatted = amount === '' ? '0' : amount
-  const amountRaw = ethers.parseUnits(amountToSendFormatted, decimals)
+  const amountRaw = parseUnits(amountToSendFormatted, decimals)
 
   const insufficientFunds = amountRaw > BigInt(tokenBalance?.balance || '0')
   const isNonZeroAmount = amountRaw > 0n
@@ -147,7 +148,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
   const handleAddOne = () => {
     amountInputRef.current?.focus()
     const incrementedAmount = Number(amount) + 1
-    const maxAmount = Number(ethers.formatUnits(tokenBalance?.balance || 0, decimals))
+    const maxAmount = Number(formatUnits(BigInt(tokenBalance?.balance || 0), decimals))
 
     const newAmount = Math.min(incrementedAmount, maxAmount).toString()
 
@@ -156,7 +157,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
 
   const handleMax = () => {
     amountInputRef.current?.focus()
-    const maxAmount = ethers.formatUnits(tokenBalance?.balance || 0, decimals).toString()
+    const maxAmount = formatUnits(BigInt(tokenBalance?.balance || 0), decimals).toString()
 
     setAmount(maxAmount)
   }
@@ -175,7 +176,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
 
     setIsCheckingFeeOptions(true)
 
-    const sendAmount = ethers.parseUnits(amountToSendFormatted, decimals)
+    const sendAmount = parseUnits(amountToSendFormatted, decimals)
     let transaction
 
     switch (contractType) {
@@ -197,7 +198,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
             accountAddress,
             toAddress,
             [tokenId],
-            [ethers.toQuantity(sendAmount)],
+            [toHex(sendAmount)],
             new Uint8Array()
           ]) as `0x${string}`
         }
@@ -228,7 +229,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
       switchChain({ chainId })
     }
 
-    const sendAmount = ethers.parseUnits(amountToSendFormatted, decimals)
+    const sendAmount = parseUnits(amountToSendFormatted, decimals)
 
     const txOptions = {
       onSettled: (result: any) => {
@@ -285,7 +286,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
               accountAddress,
               toAddress,
               [tokenId],
-              [ethers.toQuantity(sendAmount)],
+              [toHex(sendAmount)],
               new Uint8Array()
             ]) as `0x${string}`,
             gas: null
@@ -295,7 +296,7 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
     }
   }
 
-  const maxAmount = ethers.formatUnits(tokenBalance?.balance || 0, decimals).toString()
+  const maxAmount = formatUnits(BigInt(tokenBalance?.balance || 0), decimals).toString()
 
   const isMinimum = Number(amount) === 0
   const isMaximum = Number(amount) >= Number(maxAmount)

--- a/packages/react-wallet/src/views/SwapCoin/index.tsx
+++ b/packages/react-wallet/src/views/SwapCoin/index.tsx
@@ -2,8 +2,8 @@ import { Button, ChevronRightIcon, Text, NumericInput } from '@0xsequence/design
 import { ContractVerificationStatus, TokenBalance } from '@0xsequence/indexer'
 import { compareAddress, getNativeTokenInfoByChainId } from '@0xsequence/react-connect'
 import { useGetTokenBalancesSummary, useGetCoinPrices, useGetExchangeRate } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
 import { useRef, useState, ChangeEvent } from 'react'
+import { parseUnits, zeroAddress } from 'viem'
 import { useAccount, useConfig } from 'wagmi'
 
 import { SendItemInfo } from '../../components/SendItemInfo'
@@ -73,13 +73,13 @@ export const SwapCoin = ({ contractAddress, chainId }: SwapCoinProps) => {
     return null
   }
 
-  const isNativeCoin = compareAddress(contractAddress, ethers.ZeroAddress)
+  const isNativeCoin = compareAddress(contractAddress, zeroAddress)
   const decimals = isNativeCoin ? nativeTokenInfo.decimals : tokenBalance?.contractInfo?.decimals || 18
   const name = isNativeCoin ? nativeTokenInfo.name : tokenBalance?.contractInfo?.name || ''
   const imageUrl = isNativeCoin ? nativeTokenInfo.logoURI : tokenBalance?.contractInfo?.logoURI
   const symbol = isNativeCoin ? nativeTokenInfo.symbol : tokenBalance?.contractInfo?.symbol || ''
   const amountToSendFormatted = amount === '' ? '0' : amount
-  const amountRaw = ethers.parseUnits(amountToSendFormatted, decimals)
+  const amountRaw = parseUnits(amountToSendFormatted, decimals)
 
   const amountToSendFiat = computeBalanceFiat({
     balance: {

--- a/packages/react-wallet/src/views/TransactionDetails/index.tsx
+++ b/packages/react-wallet/src/views/TransactionDetails/index.tsx
@@ -14,7 +14,7 @@ import { Transaction, TxnTransfer } from '@0xsequence/indexer'
 import { compareAddress, formatDisplay, getNativeTokenInfoByChainId } from '@0xsequence/react-connect'
 import { useGetCoinPrices, useGetCollectiblePrices, useGetExchangeRate } from '@0xsequence/react-hooks'
 import dayjs from 'dayjs'
-import { ethers } from 'ethers'
+import { formatUnits, zeroAddress } from 'viem'
 import { useConfig } from 'wagmi'
 
 import { CopyButton } from '../../components/CopyButton'
@@ -49,7 +49,7 @@ export const TransactionDetails = ({ transaction }: TransactionDetailProps) => {
         }
       })
     } else {
-      const contractAddress = transfer?.contractInfo?.address || ethers.ZeroAddress
+      const contractAddress = transfer?.contractInfo?.address || zeroAddress
       const foundCoin = coins.find(
         coin => coin.chainId === transaction.chainId && compareAddress(coin.contractAddress, contractAddress)
       )
@@ -90,7 +90,7 @@ export const TransactionDetails = ({ transaction }: TransactionDetailProps) => {
     const recipientAddress = transfer.to
     const recipientAddressFormatted =
       recipientAddress.substring(0, 10) + '...' + recipientAddress.substring(transfer.to.length - 4, transfer.to.length)
-    const isNativeToken = compareAddress(transfer?.contractInfo?.address || '', ethers.ZeroAddress)
+    const isNativeToken = compareAddress(transfer?.contractInfo?.address || '', zeroAddress)
     const logoURI = isNativeToken ? nativeTokenInfo.logoURI : transfer?.contractInfo?.logoURI
     const symbol = isNativeToken ? nativeTokenInfo.symbol : transfer?.contractInfo?.symbol || ''
 
@@ -102,7 +102,7 @@ export const TransactionDetails = ({ transaction }: TransactionDetailProps) => {
           const collectibleDecimals = transfer?.tokenMetadata?.[tokenId]?.decimals || 0
           const coinDecimals = isNativeToken ? nativeTokenInfo.decimals : transfer?.contractInfo?.decimals || 0
           const decimals = isCollectible ? collectibleDecimals : coinDecimals
-          const formattedBalance = ethers.formatUnits(amount, decimals)
+          const formattedBalance = formatUnits(BigInt(amount), decimals)
           const balanceDisplayed = formatDisplay(formattedBalance)
           const fiatPrice = isCollectible
             ? collectiblePricesData?.find(
@@ -113,7 +113,7 @@ export const TransactionDetails = ({ transaction }: TransactionDetailProps) => {
               )?.price?.value
             : coinPricesData?.find(
                 coin =>
-                  compareAddress(coin.token.contractAddress, transfer.contractInfo?.address || ethers.ZeroAddress) &&
+                  compareAddress(coin.token.contractAddress, transfer.contractInfo?.address || zeroAddress) &&
                   coin.token.chainId === transaction.chainId
               )?.price?.value
 


### PR DESCRIPTION
wagmi is viem based, and sequence is ethers based. This makes it difficult to completely remove ethers completely, but we can reduce the surface area by using viem functions whenever possible. This should have ease an eventual transition off of ethers.

Before: ethers was used **101** times across **28** files.
After: ethers is still used **46** times in **10** files.