### PR TITLE
Reduce ethers

### DIFF
--- a/examples/next/src/app/components/Connected.tsx
+++ b/examples/next/src/app/components/Connected.tsx
@@ -12,10 +12,9 @@ import {
 } from '@0xsequence/react-connect'
 import { useIndexerClient } from '@0xsequence/react-hooks'
 import { useOpenWalletModal } from '@0xsequence/react-wallet'
-import { ethers } from 'ethers'
 import { CardButton, Header, WalletListItem } from 'example-shared-components'
 import { type ComponentProps, useEffect, useState } from 'react'
-import { formatUnits, parseUnits } from 'viem'
+import { encodeFunctionData, formatUnits, parseUnits } from 'viem'
 import { useAccount, useChainId, usePublicClient, useSendTransaction, useWalletClient, useWriteContract } from 'wagmi'
 
 import { isDebugMode, sponsoredContractAddresses } from '../../config'
@@ -216,9 +215,7 @@ export const Connected = () => {
       sendTransaction({ to: account, value: BigInt(0), gas: null })
     } else {
       const sponsoredContractAddress = sponsoredContractAddresses[chainId]
-
-      const contractAbiInterface = new ethers.Interface(['function demo()'])
-      const data = contractAbiInterface.encodeFunctionData('demo', []) as `0x${string}`
+      const data = encodeFunctionData({ abi: ['function demo()'], functionName: 'demo', args: [] })
 
       sendTransaction({
         to: sponsoredContractAddress,

--- a/examples/react/src/components/Connected.tsx
+++ b/examples/react/src/components/Connected.tsx
@@ -12,7 +12,6 @@ import {
   useWallets
 } from '@0xsequence/react-connect'
 import { useOpenWalletModal } from '@0xsequence/react-wallet'
-import { ethers } from 'ethers'
 import { CardButton, Header, WalletListItem } from 'example-shared-components'
 import { AnimatePresence } from 'motion/react'
 import React, { type ComponentProps, useEffect } from 'react'
@@ -270,9 +269,7 @@ export const Connected = () => {
       })
     } else {
       const sponsoredContractAddress = sponsoredContractAddresses[chainId]
-
-      const contractAbiInterface = new ethers.Interface(['function demo()'])
-      const data = contractAbiInterface.encodeFunctionData('demo', []) as `0x${string}`
+      const data = encodeFunctionData({ abi: ['function demo()'], functionName: 'demo', args: [] })
 
       sendTransaction({
         to: sponsoredContractAddress,
@@ -315,10 +312,7 @@ export const Connected = () => {
     const chainId = 137
     const currencyAddress = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
     const currencyAmount = '20000'
-
-    const contractAbiInterface = new ethers.Interface(['function demo()'])
-
-    const data = contractAbiInterface.encodeFunctionData('demo', []) as `0x${string}`
+    const data = encodeFunctionData({ abi: ['function demo()'], functionName: 'demo', args: [] })
 
     const swapModalSettings: SwapModalSettings = {
       onSuccess: () => {

--- a/packages/react-checkout/README.md
+++ b/packages/react-checkout/README.md
@@ -197,10 +197,7 @@ const MyComponent = () => {
     const chainId = 137
     const currencyAddress = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
     const currencyAmount = '20000'
-
-    const contractAbiInterface = new ethers.Interface(['function demo()'])
-
-    const data = contractAbiInterface.encodeFunctionData('demo', []) as `0x${string}`
+    const data = encodeFunctionData({ abi: ['function demo()'], functionName: 'demo', args: []})
 
     const swapModalSettings: SwapModalSettings = {
       onSuccess: () => {

--- a/packages/react-connect/src/hooks/useWaasFeeOptions.ts
+++ b/packages/react-connect/src/hooks/useWaasFeeOptions.ts
@@ -3,8 +3,9 @@
 import { ContractVerificationStatus } from '@0xsequence/indexer'
 import { useIndexerClient } from '@0xsequence/react-hooks'
 import type { FeeOption } from '@0xsequence/waas'
-import { formatUnits, type ethers } from 'ethers'
+import { type ethers } from 'ethers'
 import { useState, useEffect, useRef } from 'react'
+import { formatUnits } from 'viem'
 import type { Connector } from 'wagmi'
 import { useConnections } from 'wagmi'
 
@@ -170,7 +171,7 @@ export function useWaasFeeOptions(options?: WaasFeeOptionsConfig): UseWaasFeeOpt
                 return {
                   ...option,
                   balanceFormatted: option.token.decimals
-                    ? formatUnits(tokenBalances.balances[0]?.balance ?? '0', option.token.decimals)
+                    ? formatUnits(BigInt(tokenBalances.balances[0]?.balance ?? '0'), option.token.decimals)
                     : (tokenBalances.balances[0]?.balance ?? '0'),
                   balance: tokenBalances.balances[0]?.balance ?? '0',
                   hasEnoughBalanceForFee: tokenBalance ? BigInt(option.value) <= BigInt(tokenBalance) : false
@@ -179,7 +180,7 @@ export function useWaasFeeOptions(options?: WaasFeeOptionsConfig): UseWaasFeeOpt
               const nativeBalance = await indexerClient.getNativeTokenBalance({ accountAddress })
               return {
                 ...option,
-                balanceFormatted: formatUnits(nativeBalance.balance.balance, 18),
+                balanceFormatted: formatUnits(BigInt(nativeBalance.balance.balance), 18),
                 balance: nativeBalance.balance.balance,
                 hasEnoughBalanceForFee: BigInt(option.value) <= BigInt(nativeBalance.balance.balance)
               }

--- a/packages/react-wallet/src/components/FeeOptionSelector.tsx
+++ b/packages/react-wallet/src/components/FeeOptionSelector.tsx
@@ -1,6 +1,6 @@
 import { cn, Text, TokenImage } from '@0xsequence/design-system'
-import { ZeroAddress, formatUnits, parseUnits } from 'ethers'
 import React from 'react'
+import { formatUnits, parseUnits, zeroAddress } from 'viem'
 
 import { Alert, AlertProps } from './Alert'
 
@@ -62,7 +62,7 @@ export const FeeOptionSelector: React.FC<FeeOptionSelectorProps> = ({
       </Text>
       <div className="flex flex-col mt-2 gap-2">
         {sortedOptions.map((option, index) => {
-          const isSelected = selectedFeeOptionAddress === (option.token.contractAddress ?? ZeroAddress)
+          const isSelected = selectedFeeOptionAddress === (option.token.contractAddress ?? zeroAddress)
           const balance = feeOptionBalances.find(b => b.tokenName === option.token.name)
           const isSufficient = isBalanceSufficient(balance?.balance || '0', option.value, option.token.decimals || 0)
           return (
@@ -74,7 +74,7 @@ export const FeeOptionSelector: React.FC<FeeOptionSelectorProps> = ({
               key={index}
               onClick={() => {
                 if (isSufficient) {
-                  setSelectedFeeOptionAddress(option.token.contractAddress ?? ZeroAddress)
+                  setSelectedFeeOptionAddress(option.token.contractAddress ?? zeroAddress)
                   setFeeOptionAlert(undefined)
                 } else {
                   setFeeOptionAlert({

--- a/packages/react-wallet/src/views/SendCoin.tsx
+++ b/packages/react-wallet/src/views/SendCoin.tsx
@@ -21,9 +21,8 @@ import {
   useWaasFeeOptions
 } from '@0xsequence/react-connect'
 import { useGetTokenBalancesSummary, useGetCoinPrices, useGetExchangeRate } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
 import { useState, ChangeEvent, useRef, useEffect } from 'react'
-import { formatUnits, parseUnits, toHex, zeroAddress } from 'viem'
+import { encodeFunctionData, formatUnits, parseUnits, toHex, zeroAddress } from 'viem'
 import { useAccount, useChainId, useSwitchChain, useConfig, useSendTransaction } from 'wagmi'
 
 import { SendItemInfo } from '../components/SendItemInfo'
@@ -168,7 +167,7 @@ export const SendCoin = ({ chainId, contractAddress }: SendCoinProps) => {
     } else {
       transaction = {
         to: tokenBalance?.contractAddress as `0x${string}`,
-        data: new ethers.Interface(ERC_20_ABI).encodeFunctionData('transfer', [toAddress, toHex(sendAmount)]) as `0x${string}`
+        data: encodeFunctionData({ abi: ERC_20_ABI, functionName: 'transfer', args: [toAddress, toHex(sendAmount)] })
       }
     }
 
@@ -235,7 +234,7 @@ export const SendCoin = ({ chainId, contractAddress }: SendCoinProps) => {
       sendTransaction(
         {
           to: tokenBalance?.contractAddress as `0x${string}`,
-          data: new ethers.Interface(ERC_20_ABI).encodeFunctionData('transfer', [toAddress, toHex(sendAmount)]) as `0x${string}`,
+          data: encodeFunctionData({ abi: ERC_20_ABI, functionName: 'transfer', args: [toAddress, toHex(sendAmount)] }),
           gas: null
         },
         txOptions

--- a/packages/react-wallet/src/views/SendCollectible.tsx
+++ b/packages/react-wallet/src/views/SendCollectible.tsx
@@ -22,9 +22,8 @@ import {
   useWaasFeeOptions
 } from '@0xsequence/react-connect'
 import { useGetTokenBalancesDetails } from '@0xsequence/react-hooks'
-import { ethers } from 'ethers'
 import { useRef, useState, ChangeEvent, useEffect } from 'react'
-import { formatUnits, parseUnits, toHex } from 'viem'
+import { encodeFunctionData, formatUnits, parseUnits, toHex } from 'viem'
 import { useAccount, useChainId, useSwitchChain, useConfig, useSendTransaction } from 'wagmi'
 
 import { SendItemInfo } from '../components/SendItemInfo'
@@ -183,24 +182,22 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
       case 'ERC721':
         transaction = {
           to: (tokenBalance as TokenBalance).contractAddress as `0x${string}`,
-          data: new ethers.Interface(ERC_721_ABI).encodeFunctionData('safeTransferFrom', [
-            accountAddress,
-            toAddress,
-            tokenId
-          ]) as `0x${string}`
+          data: encodeFunctionData({
+            abi: ERC_721_ABI,
+            functionName: 'safeTransferFrom',
+            args: [accountAddress, toAddress, tokenId]
+          })
         }
         break
       case 'ERC1155':
       default:
         transaction = {
           to: (tokenBalance as TokenBalance).contractAddress as `0x${string}`,
-          data: new ethers.Interface(ERC_1155_ABI).encodeFunctionData('safeBatchTransferFrom', [
-            accountAddress,
-            toAddress,
-            [tokenId],
-            [toHex(sendAmount)],
-            new Uint8Array()
-          ]) as `0x${string}`
+          data: encodeFunctionData({
+            abi: ERC_1155_ABI,
+            functionName: 'safeBatchTransferFrom',
+            args: [accountAddress, toAddress, [tokenId], [toHex(sendAmount)], new Uint8Array()]
+          })
         }
     }
 
@@ -258,11 +255,11 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
         sendTransaction(
           {
             to: (tokenBalance as TokenBalance).contractAddress as `0x${string}`,
-            data: new ethers.Interface(ERC_721_ABI).encodeFunctionData('safeTransferFrom', [
-              accountAddress,
-              toAddress,
-              tokenId
-            ]) as `0x${string}`,
+            data: encodeFunctionData({
+              abi: ERC_721_ABI,
+              functionName: 'safeTransferFrom',
+              args: [accountAddress, toAddress, tokenId]
+            }),
             gas: null
           },
           txOptions
@@ -282,13 +279,11 @@ export const SendCollectible = ({ chainId, contractAddress, tokenId }: SendColle
         sendTransaction(
           {
             to: (tokenBalance as TokenBalance).contractAddress as `0x${string}`,
-            data: new ethers.Interface(ERC_1155_ABI).encodeFunctionData('safeBatchTransferFrom', [
-              accountAddress,
-              toAddress,
-              [tokenId],
-              [toHex(sendAmount)],
-              new Uint8Array()
-            ]) as `0x${string}`,
+            data: encodeFunctionData({
+              abi: ERC_1155_ABI,
+              functionName: 'safeBatchTransferFrom',
+              args: [accountAddress, toAddress, [tokenId], [toHex(sendAmount)], new Uint8Array()]
+            }),
             gas: null
           },
           txOptions


### PR DESCRIPTION
wagmi is viem based, and sequence is ethers based. This makes it difficult to completely remove ethers completely, but we can reduce the surface area by using viem functions whenever possible. This should have ease an eventual transition off of ethers.

Before: ethers was used **101** times across **28** files.
After: ethers is still used **26** times in **5** files.