### PR TITLE
Remove redundant QueryClientProviders from Checkout and Wallet should…

### DIFF
--- a/packages/checkout/src/components/SequenceCheckoutProvider/SequenceCheckoutProvider.tsx
+++ b/packages/checkout/src/components/SequenceCheckoutProvider/SequenceCheckoutProvider.tsx
@@ -2,7 +2,6 @@
 
 import { getModalPositionCss, ShadowRoot, useTheme } from '@0xsequence/connect'
 import { Modal } from '@0xsequence/design-system'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AnimatePresence } from 'motion/react'
 import React, { useState, useEffect } from 'react'
 
@@ -47,17 +46,7 @@ export type SequenceCheckoutProviderProps = {
   config?: SequenceCheckoutConfig
 }
 
-export const SequenceCheckoutProvider = (props: SequenceCheckoutProviderProps) => {
-  const queryClient = new QueryClient()
-
-  return (
-    <QueryClientProvider client={queryClient}>
-      <SequenceCheckoutContent {...props} />
-    </QueryClientProvider>
-  )
-}
-
-export const SequenceCheckoutContent = ({ children, config }: SequenceCheckoutProviderProps) => {
+export const SequenceCheckoutProvider = ({ children, config }: SequenceCheckoutProviderProps) => {
   const { theme, position } = useTheme()
   const [openCheckoutModal, setOpenCheckoutModal] = useState<boolean>(false)
   const [openAddFundsModal, setOpenAddFundsModal] = useState<boolean>(false)

--- a/packages/wallet-widget/src/components/SequenceWalletProvider/SequenceWalletProvider.tsx
+++ b/packages/wallet-widget/src/components/SequenceWalletProvider/SequenceWalletProvider.tsx
@@ -2,7 +2,6 @@
 
 import { getModalPositionCss, useTheme, ShadowRoot } from '@0xsequence/connect'
 import { Modal, Scroll } from '@0xsequence/design-system'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AnimatePresence } from 'motion/react'
 import React, { useState } from 'react'
 
@@ -19,17 +18,7 @@ const DEFAULT_LOCATION: Navigation = {
   location: 'home'
 }
 
-export const SequenceWalletProvider = (props: SequenceWalletProviderProps) => {
-  const queryClient = new QueryClient()
-
-  return (
-    <QueryClientProvider client={queryClient}>
-      <WalletContent {...props} />
-    </QueryClientProvider>
-  )
-}
-
-export const WalletContent = ({ children }: SequenceWalletProviderProps) => {
+export const SequenceWalletProvider = ({ children }: SequenceWalletProviderProps) => {
   const { theme, position } = useTheme()
 
   // Wallet Modal Context


### PR DESCRIPTION
… share the configured queryClient from Connect