### PR TITLE
Fixed messages not received in iframes + other fixes

### DIFF
--- a/packages/checkout/src/components/SequenceCheckoutProvider/SequenceCheckoutProvider.tsx
+++ b/packages/checkout/src/components/SequenceCheckoutProvider/SequenceCheckoutProvider.tsx
@@ -257,7 +257,7 @@ export const SequenceCheckoutProvider = ({ children, config }: SequenceCheckoutP
                           <Modal
                             contentProps={{
                               style: {
-                                maxWidth: '400px',
+                                maxWidth: '540px',
                                 height: 'auto',
                                 ...getModalPositionCss(position)
                               }
@@ -275,7 +275,7 @@ export const SequenceCheckoutProvider = ({ children, config }: SequenceCheckoutP
                           <Modal
                             contentProps={{
                               style: {
-                                maxWidth: '400px',
+                                maxWidth: '540px',
                                 height: 'auto',
                                 ...getModalPositionCss(position)
                               }

--- a/packages/checkout/src/views/AddFunds.tsx
+++ b/packages/checkout/src/views/AddFunds.tsx
@@ -1,6 +1,6 @@
 import { Spinner, Text } from '@0xsequence/design-system'
 import { useAPIClient } from '@0xsequence/hooks'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import { HEADER_HEIGHT } from '../constants'
 import { useEnvironmentContext } from '../contexts'
@@ -8,7 +8,6 @@ import { AddFundsSettings } from '../contexts/AddFundsModal'
 import { useAddFundsModal, useSardineOnRampLink } from '../hooks'
 import { getTransakLink } from '../utils/transak'
 
-const IframeId = 'sequenceOnRamp'
 const EventTypeOrderCreated = 'TRANSAK_ORDER_CREATED'
 const EventTypeOrderSuccessful = 'TRANSAK_ORDER_SUCCESSFUL'
 const EventTypeOrderFailed = 'TRANSAK_ORDER_FAILED'
@@ -30,6 +29,7 @@ export const AddFundsContentSardine = () => {
   const { sardineOnRampUrl } = useEnvironmentContext()
   const network = addFundsSettings?.networks?.split(',')?.[0]
   const apiClient = useAPIClient()
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
   const {
     data: sardineLinkOnRamp,
@@ -45,31 +45,30 @@ export const AddFundsContentSardine = () => {
   })
 
   useEffect(() => {
-    window.addEventListener('message', messageReceived)
-    return () => {
-      window.removeEventListener('message', messageReceived)
-    }
-  }, [])
-
-  function messageReceived(message: MessageEvent<any>) {
-    const element = document.getElementById(IframeId) as HTMLIFrameElement | undefined
-    const iframe = element?.contentWindow
-    if (message.source === iframe) {
-      const data = message.data
-      const status = data.status as string
-      switch (status) {
-        case 'draft':
-          addFundsSettings?.onOrderCreated?.(data)
-          break
-        case 'expired':
-        case 'decline':
-          addFundsSettings?.onOrderFailed?.(data)
-          break
-        case 'processed':
-          addFundsSettings?.onOrderSuccessful?.(data)
+    const handleMessage = (message: MessageEvent<any>) => {
+      const iframe = iframeRef.current?.contentWindow
+      if (message.source === iframe) {
+        const data = message.data
+        const status = data.status as string
+        switch (status) {
+          case 'draft':
+            addFundsSettings?.onOrderCreated?.(data)
+            break
+          case 'expired':
+          case 'decline':
+            addFundsSettings?.onOrderFailed?.(data)
+            break
+          case 'processed':
+            addFundsSettings?.onOrderSuccessful?.(data)
+        }
       }
     }
-  }
+
+    window.addEventListener('message', handleMessage)
+    return () => {
+      window.removeEventListener('message', handleMessage)
+    }
+  }, [])
 
   const Container = ({ children }: { children: React.ReactNode }) => {
     return (
@@ -103,7 +102,7 @@ export const AddFundsContentSardine = () => {
 
   return (
     <Container>
-      <iframe id={IframeId} className="w-full h-full border-0" src={sardineLinkOnRamp} allow="camera *;geolocation *" />
+      <iframe ref={iframeRef} className="w-full h-full border-0" src={sardineLinkOnRamp} allow="camera *;geolocation *" />
     </Container>
   )
 }
@@ -111,33 +110,38 @@ export const AddFundsContentSardine = () => {
 export const AddFundsContentTransak = () => {
   const { addFundsSettings = {} as AddFundsSettings } = useAddFundsModal()
   const { transakApiUrl, transakApiKey } = useEnvironmentContext()
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+
+  if (!addFundsSettings) {
+    return null
+  }
 
   useEffect(() => {
-    window.addEventListener('message', messageReceived)
-    return () => {
-      window.removeEventListener('message', messageReceived)
-    }
-  }, [])
+    const handleMessage = (message: MessageEvent<any>) => {
+      const iframe = iframeRef.current?.contentWindow
 
-  function messageReceived(message: MessageEvent<any>) {
-    const element = document.getElementById(IframeId) as HTMLIFrameElement | undefined
-    const iframe = element?.contentWindow
-    if (message.source === iframe) {
-      const data = message.data
-      const eventType = data.eventType as string
-      switch (eventType) {
-        case EventTypeOrderCreated:
-          addFundsSettings?.onOrderCreated?.(data)
-          break
-        case EventTypeOrderSuccessful:
-          addFundsSettings?.onOrderSuccessful?.(data)
-          break
-        case EventTypeOrderFailed:
-          addFundsSettings?.onOrderFailed?.(data)
-          break
+      if (message.source === iframe) {
+        const data = message.data
+        const eventType = data.eventType as string
+        switch (eventType) {
+          case EventTypeOrderCreated:
+            addFundsSettings?.onOrderCreated?.(data)
+            break
+          case EventTypeOrderSuccessful:
+            addFundsSettings?.onOrderSuccessful?.(data)
+            break
+          case EventTypeOrderFailed:
+            addFundsSettings?.onOrderFailed?.(data)
+            break
+        }
       }
     }
-  }
+
+    window.addEventListener('message', handleMessage)
+    return () => {
+      window.removeEventListener('message', handleMessage)
+    }
+  }, [])
 
   const link = getTransakLink(addFundsSettings, {
     transakApiUrl,
@@ -152,7 +156,7 @@ export const AddFundsContentTransak = () => {
         paddingTop: HEADER_HEIGHT
       }}
     >
-      <iframe className="w-full h-full border-0" id={IframeId} src={link} allow="camera;microphone;payment" />
+      <iframe ref={iframeRef} className="w-full h-full border-0" src={link} allow="camera;microphone;payment" />
     </div>
   )
 }

--- a/packages/checkout/src/views/PaymentSelection/FundWithFiat.tsx
+++ b/packages/checkout/src/views/PaymentSelection/FundWithFiat.tsx
@@ -9,11 +9,12 @@ interface FundWithFiatProps {
   walletAddress: string
   provider: TransactionOnRampProvider
   chainId: number
+  onClick: () => void
 }
 
-export const FundWithFiat = ({ cryptoSymbol, walletAddress, provider, chainId }: FundWithFiatProps) => {
+export const FundWithFiat = ({ cryptoSymbol, walletAddress, provider, chainId, onClick: onClickCallback }: FundWithFiatProps) => {
   const { triggerAddFunds } = useAddFundsModal()
-  const { closeSelectPaymentModal } = useSelectPaymentModal()
+  const { closeSelectPaymentModal, selectPaymentSettings } = useSelectPaymentModal()
 
   const getNetworks = (): string | undefined => {
     const network = findSupportedNetwork(chainId)
@@ -21,12 +22,14 @@ export const FundWithFiat = ({ cryptoSymbol, walletAddress, provider, chainId }:
   }
 
   const onClick = () => {
+    onClickCallback()
     closeSelectPaymentModal()
     triggerAddFunds({
       walletAddress,
       provider,
       networks: getNetworks(),
-      defaultCryptoCurrency: cryptoSymbol
+      defaultCryptoCurrency: cryptoSymbol,
+      onClose: selectPaymentSettings?.onClose
     })
   }
 

--- a/packages/checkout/src/views/PaymentSelection/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/index.tsx
@@ -451,6 +451,9 @@ export const PaymentSelectionContent = () => {
                 walletAddress={userAddress || ''}
                 provider={onRampProvider}
                 chainId={chainId}
+                onClick={() => {
+                  skipOnCloseCallback()
+                }}
               />
             )}
           </>

--- a/packages/checkout/src/views/PendingCreditCardTransaction.tsx
+++ b/packages/checkout/src/views/PendingCreditCardTransaction.tsx
@@ -203,7 +203,7 @@ export const PendingCreditCardTransactionTransak = ({ skipOnCloseCallback }: Pen
         className="flex flex-col justify-center items-center gap-6"
         style={{
           height: '650px',
-          width: '380px'
+          width: '500px'
         }}
       >
         <div>
@@ -223,7 +223,7 @@ export const PendingCreditCardTransactionTransak = ({ skipOnCloseCallback }: Pen
         className="flex flex-col justify-center items-center gap-6"
         style={{
           height: '650px',
-          width: '380px'
+          width: '500px'
         }}
       >
         <div>
@@ -242,7 +242,7 @@ export const PendingCreditCardTransactionTransak = ({ skipOnCloseCallback }: Pen
         style={{
           maxHeight: '650px',
           height: '100%',
-          maxWidth: '380px',
+          maxWidth: '500px',
           width: '100%'
         }}
       />
@@ -389,7 +389,7 @@ export const PendingCreditCardTransactionSardine = ({ skipOnCloseCallback }: Pen
         className="flex flex-col justify-center items-center gap-6"
         style={{
           height: '650px',
-          width: '380px'
+          width: '500px'
         }}
       >
         <div>
@@ -405,7 +405,7 @@ export const PendingCreditCardTransactionSardine = ({ skipOnCloseCallback }: Pen
         className="flex flex-col justify-center items-center gap-6"
         style={{
           height: '650px',
-          width: '380px'
+          width: '500px'
         }}
       >
         <div>
@@ -423,7 +423,7 @@ export const PendingCreditCardTransactionSardine = ({ skipOnCloseCallback }: Pen
         style={{
           maxHeight: '650px',
           height: '100%',
-          maxWidth: '380px',
+          maxWidth: '500px',
           width: '100%'
         }}
       />

--- a/packages/checkout/src/views/PendingCreditCardTransaction.tsx
+++ b/packages/checkout/src/views/PendingCreditCardTransaction.tsx
@@ -3,7 +3,7 @@ import { Spinner, Text } from '@0xsequence/design-system'
 import { useConfig, useGetTokenMetadata, useGetContractInfo } from '@0xsequence/hooks'
 import { findSupportedNetwork } from '@0xsequence/network'
 import pako from 'pako'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { formatUnits } from 'viem'
 
 import { fetchSardineOrderStatus } from '../api'
@@ -49,6 +49,7 @@ export const PendingCreditCardTransactionTransak = ({ skipOnCloseCallback }: Pen
   const { openTransactionStatusModal } = useTransactionStatusModal()
   const nav = useNavigation()
   const { settings, closeCheckout } = useCheckoutModal()
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
   const {
     params: { creditCardCheckout }
@@ -126,14 +127,9 @@ export const PendingCreditCardTransactionTransak = ({ skipOnCloseCallback }: Pen
   const isError = isErrorTokenMetadata || isErrorCollectionInfo
 
   useEffect(() => {
-    const transakIframeElement = document.getElementById('transakIframe') as HTMLIFrameElement
-    if (!transakIframeElement) {
-      return
-    }
-    const transakIframe = transakIframeElement.contentWindow
-
     const readMessage = (message: any) => {
-      if (message.source !== transakIframe) {
+      const transakIframe = iframeRef.current?.contentWindow
+      if (!transakIframe || message.source !== transakIframe) {
         return
       }
 
@@ -240,7 +236,7 @@ export const PendingCreditCardTransactionTransak = ({ skipOnCloseCallback }: Pen
   return (
     <div className="flex items-center justify-center" style={{ height: '770px' }}>
       <iframe
-        id="transakIframe"
+        ref={iframeRef}
         allow="camera;microphone;payment"
         src={transakLink}
         style={{
@@ -261,6 +257,8 @@ export const PendingCreditCardTransactionSardine = ({ skipOnCloseCallback }: Pen
   const { closeCheckout } = useCheckoutModal()
   const { sardineCheckoutUrl: sardineProxyUrl } = useEnvironmentContext()
   const { env } = useConfig()
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+
   const {
     params: { creditCardCheckout }
   } = nav.navigation as TransactionPendingNavigation
@@ -420,6 +418,7 @@ export const PendingCreditCardTransactionSardine = ({ skipOnCloseCallback }: Pen
   return (
     <div className="flex items-center justify-center" style={{ height: '770px' }}>
       <iframe
+        ref={iframeRef}
         src={url}
         style={{
           maxHeight: '650px',


### PR DESCRIPTION
- Fixed messages not being received in transak/sardine iframes. It seems the newly added shadowRoot negatively impacted the DOM query. DOM querying was replaced by using refs to track source of the message

- Made the iframes slightly larger to fit the recommended size from Transak

- Fixed the the onClose callback being called when going from the checkout modal to the funding with credit card modal