### PR TITLE
Fix icons

### DIFF
--- a/examples/components/package.json
+++ b/examples/components/package.json
@@ -8,7 +8,7 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "@0xsequence/design-system": "^2.0.11",
+    "@0xsequence/design-system": "2.0.12",
     "@0xsequence/network": "*",
     "wagmi": "^2.14.13"
   },

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@0xsequence/design-system": "^2.0.11",
+    "@0xsequence/design-system": "2.0.12",
     "@0xsequence/network": ">= 2.2.13",
     "@0xsequence/checkout": "workspace:*",
     "@0xsequence/connect": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@0xsequence/checkout": "workspace:*",
     "@0xsequence/connect": "workspace:*",
-    "@0xsequence/design-system": "^2.0.11",
+    "@0xsequence/design-system": "2.0.12",
     "@0xsequence/network": ">= 2.2.13",
     "@0xsequence/waas": ">= 2.2.13",
     "@0xsequence/wallet-widget": "workspace:*",

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -30,7 +30,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@0xsequence/design-system": "^2.0.11",
+    "@0xsequence/design-system": "2.0.12",
     "@0xsequence/marketplace": "^2.1.3",
     "@0xsequence/hooks": "workspace:*",
     "pako": "^2.1.0",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -40,7 +40,7 @@
     "@0xsequence/api": ">= 2.2.13",
     "@0xsequence/auth": ">= 2.2.13",
     "@0xsequence/core": ">= 2.2.13",
-    "@0xsequence/design-system": "^2.0.11",
+    "@0xsequence/design-system": "2.0.12",
     "@0xsequence/ethauth": "^1.0.0",
     "@0xsequence/hooks": "workspace:*",
     "@0xsequence/indexer": ">= 2.2.13",

--- a/packages/connect/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/connect/src/components/ConnectButton/ConnectButton.tsx
@@ -1,4 +1,4 @@
-import { Card, EllipsisIcon, Text, Tooltip, useTheme } from '@0xsequence/design-system'
+import { Card, ContextMenuIcon, Text, Tooltip, useTheme } from '@0xsequence/design-system'
 import { GoogleLogin } from '@react-oauth/google'
 import { appleAuthHelpers } from 'react-apple-signin-auth'
 
@@ -81,7 +81,7 @@ export const ShowAllWalletsButton = ({ onClick }: ShowAllWalletsButtonProps) => 
           height: BUTTON_HEIGHT
         }}
       >
-        <EllipsisIcon className="text-primary" size="xl" />
+        <ContextMenuIcon className="text-primary" size="xl" />
       </Card>
     </Tooltip>
   )

--- a/packages/wallet-widget/package.json
+++ b/packages/wallet-widget/package.json
@@ -30,7 +30,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@0xsequence/design-system": "^2.0.11",
+    "@0xsequence/design-system": "2.0.12",
     "@0xsequence/hooks": "workspace:*",
     "@radix-ui/react-popover": "^1.0.7",
     "dayjs": "^1.11.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
   examples/components:
     dependencies:
       '@0xsequence/design-system':
-        specifier: ^2.0.11
-        version: 2.0.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 2.0.12
+        version: 2.0.12(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@0xsequence/network':
         specifier: '*'
         version: 2.2.13(ethers@6.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -102,8 +102,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/connect
       '@0xsequence/design-system':
-        specifier: ^2.0.11
-        version: 2.0.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 2.0.12
+        version: 2.0.12(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@0xsequence/hooks':
         specifier: workspace:*
         version: link:../../packages/hooks
@@ -175,8 +175,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/connect
       '@0xsequence/design-system':
-        specifier: ^2.0.11
-        version: 2.0.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 2.0.12
+        version: 2.0.12(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@0xsequence/network':
         specifier: '>= 2.2.13'
         version: 2.2.13(ethers@6.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -257,8 +257,8 @@ importers:
         specifier: '>= 2.2.13'
         version: 2.2.13
       '@0xsequence/design-system':
-        specifier: ^2.0.11
-        version: 2.0.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 2.0.12
+        version: 2.0.12(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@0xsequence/hooks':
         specifier: workspace:*
         version: link:../hooks
@@ -336,8 +336,8 @@ importers:
         specifier: '>= 2.2.13'
         version: 2.2.13(ethers@6.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@0xsequence/design-system':
-        specifier: ^2.0.11
-        version: 2.0.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 2.0.12
+        version: 2.0.12(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@0xsequence/ethauth':
         specifier: ^1.0.0
         version: 1.0.0(ethers@6.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -472,8 +472,8 @@ importers:
         specifier: '>= 2.2.13'
         version: 2.2.13
       '@0xsequence/design-system':
-        specifier: ^2.0.11
-        version: 2.0.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 2.0.12
+        version: 2.0.12(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@0xsequence/hooks':
         specifier: workspace:*
         version: link:../hooks
@@ -558,8 +558,8 @@ packages:
     peerDependencies:
       ethers: '>=6'
 
-  '@0xsequence/design-system@2.0.11':
-    resolution: {integrity: sha512-UpL8pfmJLTq0376CFwAemPYIetXR2TYOHoTIoisroT53kOdSvCx3cT1nAaMr8lr2xfCz88+KvgsxK/5ZYye4OA==}
+  '@0xsequence/design-system@2.0.12':
+    resolution: {integrity: sha512-4pvRg+WdURUr2dFl8t2r/YkL3AGzYfNYbrCc06julSBVzaGIWAElGRBnnPYIFLjBAOBEJ5iTQVCLmSQ6+JnA6g==}
     peerDependencies:
       motion: '>= 12'
       react: '>= 17'
@@ -6558,7 +6558,7 @@ snapshots:
       '@0xsequence/utils': 2.2.13(ethers@6.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ethers: 6.13.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  '@0xsequence/design-system@2.0.11(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@0xsequence/design-system@2.0.12(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(motion@12.4.10(@emotion/is-prop-valid@0.8.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-aspect-ratio': 1.1.2(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-checkbox': 1.1.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
design-system version was too loose and automatically updated to v2.1.0 which has a new icon set where some are removed/renamed which caused import problems for those freshly installing the web-sdk