### PR TITLE
fix: checkout purchase modal

### DIFF
--- a/packages/checkout/src/views/PaymentSelection/PayWithCrypto/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/PayWithCrypto/index.tsx
@@ -1,6 +1,7 @@
+import type { LifiSwapRoute } from '@0xsequence/api'
 import { compareAddress, ContractVerificationStatus, CryptoOption, formatDisplay } from '@0xsequence/connect'
 import { AddIcon, Button, Spinner, SubtractIcon, Text } from '@0xsequence/design-system'
-import { useClearCachedBalances, useGetContractInfo, useGetSwapRoutes, useGetTokenBalancesSummary } from '@0xsequence/hooks'
+import { useClearCachedBalances, useGetContractInfo, useGetTokenBalancesSummary } from '@0xsequence/hooks'
 import { findSupportedNetwork } from '@0xsequence/network'
 import { motion } from 'motion/react'
 import { Fragment, useEffect, useMemo, useState, type SetStateAction } from 'react'
@@ -15,6 +16,8 @@ interface PayWithCryptoProps {
   selectedCurrency: string | undefined
   setSelectedCurrency: React.Dispatch<SetStateAction<string | undefined>>
   isLoading: boolean
+  swapRoutes: LifiSwapRoute[]
+  swapRoutesIsLoading: boolean
 }
 
 const MAX_OPTIONS = 3
@@ -24,7 +27,9 @@ export const PayWithCrypto = ({
   disableButtons,
   selectedCurrency,
   setSelectedCurrency,
-  isLoading
+  isLoading,
+  swapRoutes,
+  swapRoutesIsLoading
 }: PayWithCryptoProps) => {
   const [showMore, setShowMore] = useState(false)
   const { enableSwapPayments = true, enableMainCurrencyPayment = true } = settings
@@ -39,16 +44,6 @@ export const PayWithCrypto = ({
     chainID: String(chainId),
     contractAddress: currencyAddress
   })
-
-  const { data: swapRoutes = [], isLoading: swapRoutesIsLoading } = useGetSwapRoutes(
-    {
-      walletAddress: userAddress ?? '',
-      chainId,
-      toTokenAmount: price,
-      toTokenAddress: currencyAddress
-    },
-    { disabled: !enableSwapPayments || !userAddress }
-  )
 
   const tokenAddressesToFetch = useMemo(() => {
     const addresses = new Set<string>()

--- a/packages/checkout/src/views/PaymentSelection/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/index.tsx
@@ -111,7 +111,7 @@ export const PaymentSelectionContent = () => {
       toTokenAmount: price,
       toTokenAddress: currencyAddress
     },
-    { disabled: !enableSwapPayments }
+    { disabled: !enableSwapPayments, retry: 3 }
   )
 
   const disableSwapQuote = !selectedCurrency || compareAddress(selectedCurrency, buyCurrencyAddress)
@@ -412,6 +412,8 @@ export const PaymentSelectionContent = () => {
               selectedCurrency={selectedCurrency}
               setSelectedCurrency={setSelectedCurrency}
               isLoading={isLoading}
+              swapRoutes={swapRoutes}
+              swapRoutesIsLoading={swapRoutesIsLoading}
             />
           </>
         )}
@@ -464,13 +466,7 @@ export const PaymentSelectionContent = () => {
               <Button
                 className="mt-6 w-full"
                 onClick={onClickPurchase}
-                disabled={
-                  isLoading ||
-                  disableButtons ||
-                  !selectedCurrency ||
-                  swapRoutesIsLoading ||
-                  (!disableSwapQuote && isLoadingSwapQuote)
-                }
+                disabled={isLoading || disableButtons || !selectedCurrency || (!disableSwapQuote && isLoadingSwapQuote)}
                 shape="square"
                 variant="primary"
                 label="Complete Purchase"

--- a/packages/connect/src/styles.ts
+++ b/packages/connect/src/styles.ts
@@ -304,6 +304,9 @@ export const styles = String.raw`
   .my-4 {
     margin-block: calc(var(--spacing) * 4);
   }
+  .mt-0 {
+    margin-top: calc(var(--spacing) * 0);
+  }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
   }
@@ -378,6 +381,9 @@ export const styles = String.raw`
   }
   .inline-flex {
     display: inline-flex;
+  }
+  .table {
+    display: table;
   }
   .aspect-square {
     aspect-ratio: 1 / 1;
@@ -471,6 +477,9 @@ export const styles = String.raw`
   }
   .min-h-full {
     min-height: 100%;
+  }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
   }
   .w-1\/2 {
     width: calc(1/2 * 100%);
@@ -568,11 +577,20 @@ export const styles = String.raw`
   .min-w-full {
     min-width: 100%;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .shrink-0 {
     flex-shrink: 0;
   }
+  .flex-grow {
+    flex-grow: 1;
+  }
   .grow {
     flex-grow: 1;
+  }
+  .border-collapse {
+    border-collapse: collapse;
   }
   .origin-top {
     transform-origin: top;
@@ -951,6 +969,9 @@ export const styles = String.raw`
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
   }
+  .pt-1 {
+    padding-top: calc(var(--spacing) * 1);
+  }
   .pt-1\.5 {
     padding-top: calc(var(--spacing) * 1.5);
   }
@@ -1243,6 +1264,9 @@ export const styles = String.raw`
   .ring-border-normal {
     --tw-ring-color: var(--seq-color-border-normal);
   }
+  .ring-white {
+    --tw-ring-color: var(--color-white);
+  }
   .ring-white\/10 {
     --tw-ring-color: color-mix(in srgb, #fff 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1278,6 +1302,10 @@ export const styles = String.raw`
   }
   .backdrop-blur-xs {
     --tw-backdrop-blur: blur(var(--blur-xs));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }

--- a/packages/hooks/src/types/hooks.ts
+++ b/packages/hooks/src/types/hooks.ts
@@ -1,4 +1,4 @@
 export interface HooksOptions {
   disabled?: boolean
-  retry?: boolean
+  retry?: boolean | number
 }


### PR DESCRIPTION
Ignore swap routes state for direct currency payment for marketplace contracts.
Remove extra API call to swap routes and pass routes through props.
Added a retry limit of 3.