### PR TITLE
Remove copy to clipboard

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -58,8 +58,5 @@
     "viem": "^2.28.1",
     "vite": "^6.3.4",
     "vitest": "^2.1.9"
-  },
-  "dependencies": {
-    "copy-to-clipboard": "^3.3.3"
   }
 }

--- a/packages/hooks/src/hooks/useClipboard.ts
+++ b/packages/hooks/src/hooks/useClipboard.ts
@@ -1,4 +1,3 @@
-import copy from 'copy-to-clipboard'
 import { useEffect, useState } from 'react'
 
 interface UseClipboardProps {
@@ -23,9 +22,18 @@ export const useClipboard = (props?: UseClipboardProps) => {
 
   return [
     isCopied,
-    (text: string) => {
-      copy(text)
-      setIsCopied(true)
+    async (text: string) => {
+      return copy(text).then(() => {
+        setIsCopied(true)
+      })
     }
   ] as const
+}
+
+const copy = async (text: string): Promise<void> => {
+  if (!navigator?.clipboard) {
+    throw new Error('Clipboard API not supported')
+  }
+
+  return navigator.clipboard.writeText(text)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,10 +428,6 @@ importers:
         version: 2.15.2(@tanstack/query-core@5.75.0)(@tanstack/react-query@5.75.2(react@19.1.0))(@types/react@19.1.2)(bufferutil@4.0.9)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.28.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))(zod@3.24.4)
 
   packages/hooks:
-    dependencies:
-      copy-to-clipboard:
-        specifier: ^3.3.3
-        version: 3.3.3
     devDependencies:
       '@0xsequence/api':
         specifier: 2.3.11
@@ -4200,9 +4196,6 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
 
-  copy-to-clipboard@3.3.3:
-    resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
-
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -7049,9 +7042,6 @@ packages:
 
   toformat@2.0.0:
     resolution: {integrity: sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==}
-
-  toggle-selection@1.0.6:
-    resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -13273,10 +13263,6 @@ snapshots:
 
   cookie@1.0.2: {}
 
-  copy-to-clipboard@3.3.3:
-    dependencies:
-      toggle-selection: 1.0.6
-
   core-util-is@1.0.3: {}
 
   cors@2.8.5:
@@ -16662,8 +16648,6 @@ snapshots:
       is-number: 7.0.0
 
   toformat@2.0.0: {}
-
-  toggle-selection@1.0.6: {}
 
   toidentifier@1.0.1: {}
 


### PR DESCRIPTION
This simply removes the older copy-to-clipboard library and replaces it with native browser navigator clipboard support.