### PR TITLE
fix for infinite retries

### DIFF
--- a/packages/connect/src/hooks/useStorage.ts
+++ b/packages/connect/src/hooks/useStorage.ts
@@ -96,7 +96,6 @@ export const useStorageItem = <K extends keyof StorageItem>(key: K): UseQueryRes
     queryFn: async () => {
       return storage?.getItem(key)
     },
-    retry: true,
     enabled: !!storage
   })
 }

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -70,8 +70,7 @@ const { data, isLoading, error } = useGetCoinPrices(
   ],
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -91,8 +90,7 @@ const { data, isLoading, error } = useGetCollectiblePrices(
   ],
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -104,8 +102,7 @@ import { useGetExchangeRate } from '@0xsequence/hooks'
 
 const { data, isLoading, error } = useGetExchangeRate('CAD', {
   // options param is optional and default values are below
-  disabled: false,
-  retry: true
+  disabled: false
 })
 ```
 
@@ -125,7 +122,6 @@ const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage, error }
   {
     // options param is optional and default values are below
     disabled: false,
-    retry: true
   }
 })
 ```
@@ -142,8 +138,7 @@ const { data, isLoading, error } = useGetTransactionHistorySummary(
   },
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -161,8 +156,7 @@ const { data, isLoading, error } = useGetNativeTokenBalance(
   },
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -192,8 +186,7 @@ const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage, error }
   },
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -223,8 +216,7 @@ const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage, error }
   },
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -254,8 +246,7 @@ const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage, error }
   },
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -284,8 +275,7 @@ const { data, isLoading, error } = useGetContractInfo(
   },
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -302,8 +292,7 @@ const { data, isLoading, error } = useGetMultipleContractInfo(
   ],
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```
@@ -321,8 +310,7 @@ const { data, isLoading, error } = useGetTokenMetadata(
   },
   {
     // options param is optional and default values are below
-    disabled: false,
-    retry: true
+    disabled: false
   }
 )
 ```

--- a/packages/hooks/src/hooks/API/useGetCoinPrices.ts
+++ b/packages/hooks/src/hooks/API/useGetCoinPrices.ts
@@ -37,7 +37,7 @@ const getCoinPrices = async (apiClient: SequenceAPIClient, tokens: Token[]) => {
  *   - contractAddress: The token's contract address (use ZERO_ADDRESS for native tokens)
  *
  * @param options - Optional configuration options:
- *   - retry: Whether to retry failed requests (defaults to true)
+ *   - retry: Whether to retry failed requests (defaults to false)
  *   - disabled: Whether to disable the query
  *
  * @returns React Query result object containing:
@@ -75,7 +75,7 @@ export const useGetCoinPrices = (tokens: Token[], options?: HooksOptions) => {
   return useQuery({
     queryKey: [QUERY_KEYS.useGetCoinPrices, tokens, options],
     queryFn: () => getCoinPrices(apiClient, tokens),
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneMinute,
     enabled: tokens.length > 0 && !options?.disabled
   })

--- a/packages/hooks/src/hooks/API/useGetCollectiblePrices.ts
+++ b/packages/hooks/src/hooks/API/useGetCollectiblePrices.ts
@@ -40,7 +40,7 @@ const getCollectiblePrices = async (apiClient: SequenceAPIClient, tokens: Token[
  *   - tokenId: The specific token ID within the collection
  *
  * @param options - Optional configuration options:
- *   - retry: Whether to retry failed requests (defaults to true)
+ *   - retry: Whether to retry failed requests (defaults to false)
  *   - disabled: Whether to disable the query
  *
  * @returns React Query result object containing:
@@ -80,7 +80,7 @@ export const useGetCollectiblePrices = (tokens: Token[], options?: HooksOptions)
   return useQuery({
     queryKey: [QUERY_KEYS.useGetCollectiblePrices, tokens, options],
     queryFn: () => getCollectiblePrices(apiClient, tokens),
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneMinute,
     enabled: tokens.length > 0 && !options?.disabled
   })

--- a/packages/hooks/src/hooks/API/useGetExchangeRate.ts
+++ b/packages/hooks/src/hooks/API/useGetExchangeRate.ts
@@ -19,7 +19,7 @@ import { useAPIClient } from './useAPIClient.js'
  *                     If 'USD' is provided, returns 1 as the conversion rate.
  *
  * @param options - Optional configuration options:
- *   - retry: Whether to retry failed requests (defaults to true)
+ *   - retry: Whether to retry failed requests (defaults to false)
  *   - disabled: Whether to disable the query
  *
  * @returns React Query result object containing:
@@ -58,7 +58,7 @@ export const useGetExchangeRate = (toCurrency: string, options?: HooksOptions) =
 
       return res.exchangeRate.value
     },
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneMinute * 10,
     enabled: !!toCurrency && !options?.disabled
   })

--- a/packages/hooks/src/hooks/Combination/useGetSwapQuote.ts
+++ b/packages/hooks/src/hooks/Combination/useGetSwapQuote.ts
@@ -111,7 +111,7 @@ export const useGetSwapQuote = (getSwapQuoteArgs: GetLifiSwapQuoteArgs, options?
         currencyAddress: compareAddress(res.quote.currencyAddress, ZERO_ADDRESS) ? ZERO_ADDRESS : res.quote.currencyAddress
       }
     },
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneMinute * 1,
     enabled:
       !options?.disabled &&

--- a/packages/hooks/src/hooks/Combination/useGetSwapRoutes.ts
+++ b/packages/hooks/src/hooks/Combination/useGetSwapRoutes.ts
@@ -57,7 +57,7 @@ const getSwapRoutes = async (
  *   - toTokenAmount: The amount of the token to buy
  *
  * @param options - Optional configuration options:
- *   - retry: Whether to retry failed requests (defaults to true)
+ *   - retry: Whether to retry failed requests (defaults to false)
  *   - disabled: Whether to disable the query
  *
  * @returns React Query result object containing:
@@ -93,7 +93,7 @@ export const useGetSwapRoutes = (args: UseGetSwapRoutesArgs, options?: HooksOpti
   return useQuery({
     queryKey: [QUERY_KEYS.useGetSwapRoutes, args, options],
     queryFn: () => getSwapRoutes(apiClient, args),
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     // We must keep a long staletime to avoid the list of quotes being refreshed while the user is doing the transactions
     // Instead, we will invalidate the query manually
     staleTime: time.oneHour,

--- a/packages/hooks/src/hooks/Indexer/useGetTransactionHistory.ts
+++ b/packages/hooks/src/hooks/Indexer/useGetTransactionHistory.ts
@@ -143,7 +143,7 @@ export const useGetTransactionHistory = (args: UseGetTransactionHistoryArgs, opt
       return page?.more ? page : undefined
     },
     initialPageParam: { pageSize: args.page?.pageSize } as Page,
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneSecond * 30,
     enabled: !!args.chainId && args.accountAddresses.length > 0 && !options?.disabled
   })

--- a/packages/hooks/src/hooks/Indexer/useGetTransactionHistorySummary.ts
+++ b/packages/hooks/src/hooks/Indexer/useGetTransactionHistorySummary.ts
@@ -60,7 +60,7 @@ const getTransactionHistorySummary = async (
  * @param getTransactionHistorySummaryArgs.chainIds - Array of chain IDs to fetch transactions from. Each chain ID will be queried in parallel.
  * @param options - Optional configuration for the hook behavior
  * @param options.disabled - If true, disables the query
- * @param options.retry - If true (default), retries failed requests
+ * @param options.retry - If false, retries failed requests
  *
  * @returns A React Query result object containing:
  * - data: Array of Transaction objects combined from all specified chains, each containing:
@@ -125,7 +125,7 @@ export const useGetTransactionHistorySummary = (
     queryFn: async () => {
       return await getTransactionHistorySummary(indexerClients, getTransactionHistorySummaryArgs)
     },
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneSecond * 30,
     refetchOnMount: true,
     enabled:

--- a/packages/hooks/src/hooks/IndexerGateway/useGetNativeTokenBalance.ts
+++ b/packages/hooks/src/hooks/IndexerGateway/useGetNativeTokenBalance.ts
@@ -57,7 +57,7 @@ export const useGetNativeTokenBalance = (args: IndexerGateway.GetNativeTokenBala
   return useQuery({
     queryKey: [QUERY_KEYS.useGetNativeTokenBalance, args, options],
     queryFn: async () => await getNativeTokenBalance(indexerGatewayClient, args),
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneSecond * 30,
     enabled: !!args.accountAddress && !options?.disabled
   })

--- a/packages/hooks/src/hooks/IndexerGateway/useGetSingleTokenBalance.ts
+++ b/packages/hooks/src/hooks/IndexerGateway/useGetSingleTokenBalance.ts
@@ -83,7 +83,7 @@ export const useGetSingleTokenBalance = (args: GetSingleTokenBalanceArgs, option
     queryFn: async () => {
       return await getSingleTokenBalance(args, indexerGatewayClient)
     },
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneSecond * 30,
     enabled: !!args.chainId && !!args.accountAddress && !options?.disabled
   })

--- a/packages/hooks/src/hooks/IndexerGateway/useGetTokenBalancesByContract.ts
+++ b/packages/hooks/src/hooks/IndexerGateway/useGetTokenBalancesByContract.ts
@@ -84,7 +84,7 @@ export const useGetTokenBalancesByContract = (args: IndexerGateway.GetTokenBalan
       return page?.more ? page : undefined
     },
     initialPageParam: { pageSize: args.page?.pageSize } as Page,
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneSecond * 30,
     enabled: args.filter.contractAddresses.length > 0 && !options?.disabled
   })

--- a/packages/hooks/src/hooks/Metadata/useGetContractInfo.ts
+++ b/packages/hooks/src/hooks/Metadata/useGetContractInfo.ts
@@ -22,7 +22,7 @@ import { useMetadataClient } from './useMetadataClient.js'
  * @param getContractInfoArgs.contractAddress - Contract address or ZERO_ADDRESS for native token
  * @param options - Optional configuration for the query behavior
  * @param options.disabled - If true, disables the query from automatically running
- * @param options.retry - If true (default), retries failed queries
+ * @param options.retry - If true, retries failed queries
  *
  * Query configuration:
  * - Marks data as stale after 10 minutes
@@ -92,7 +92,7 @@ export const useGetContractInfo = (args: GetContractInfoArgs, options?: HooksOpt
           : {})
       }
     },
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneMinute * 10,
     enabled: !!args.chainID && !!args.contractAddress && !options?.disabled
   })

--- a/packages/hooks/src/hooks/Metadata/useGetMultipleContractsInfo.ts
+++ b/packages/hooks/src/hooks/Metadata/useGetMultipleContractsInfo.ts
@@ -35,7 +35,7 @@ const getMultipleContractsInfo = async (
  * @param useGetMultipleContractsInfoArgs[].contractAddress - Contract address to fetch info for
  * @param options - Optional configuration for the query behavior
  * @param options.disabled - If true, disables the query from automatically running
- * @param options.retry - If true (default), retries failed queries
+ * @param options.retry - If true, retries failed queries
  *
  * Query configuration:
  * - Uses a 1 hour stale time (compared to 10 minutes for single contract info)
@@ -116,7 +116,7 @@ export const useGetMultipleContractsInfo = (args: GetContractInfoArgs[], options
   return useQuery({
     queryKey: [QUERY_KEYS.useGetMultipleContractInfo, args, options],
     queryFn: async () => await getMultipleContractsInfo(metadataClient, args),
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneHour,
     enabled: !options?.disabled
   })

--- a/packages/hooks/src/hooks/Metadata/useGetTokenMetadata.ts
+++ b/packages/hooks/src/hooks/Metadata/useGetTokenMetadata.ts
@@ -52,7 +52,7 @@ const getTokenMetadata = async (metadataClient: SequenceMetadata, args: GetToken
  * @param getTokenMetadataArgs.tokenIDs - Array of token IDs to fetch metadata for. Each ID represents a specific token
  * @param options - Optional configuration for the query behavior
  * @param options.disabled - If true, disables the query from automatically running
- * @param options.retry - If true (default), retries failed queries
+ * @param options.retry - If true, retries failed queries
  *
  * Query configuration:
  * - Marks data as stale after 1 hour
@@ -127,7 +127,7 @@ export const useGetTokenMetadata = (args: GetTokenMetadataArgs, options?: HooksO
   return useQuery({
     queryKey: [QUERY_KEYS.useGetTokenMetadata, args, options],
     queryFn: () => getTokenMetadata(metadataClient, args, env.imageProxyUrl),
-    retry: options?.retry ?? true,
+    retry: options?.retry ?? false,
     staleTime: time.oneHour,
     enabled: !!args.chainID && !!args.contractAddress && !options?.disabled
   })

--- a/packages/wallet-widget/src/views/SwapCoin/SwapList.tsx
+++ b/packages/wallet-widget/src/views/SwapCoin/SwapList.tsx
@@ -337,6 +337,7 @@ export const SwapList = ({ chainId, contractAddress, amount, slippageBps }: Swap
               noOptionsFound ||
               !selectedCurrency ||
               quoteFetchInProgress ||
+              isErrorSwapQuote ||
               isTxsPending ||
               (!isCorrectChainId && !isConnectorSequenceBased) ||
               showSwitchNetwork


### PR DESCRIPTION
Fix for problem related to infinite retries. We are now avoiding using `retry: true` for the react query hooks since that will cause failed http request to retry infinitely.