### PR TITLE
handle undefined token ids for erc-721 sale contracts

### DIFF
--- a/examples/react/src/components/Connected.tsx
+++ b/examples/react/src/components/Connected.tsx
@@ -27,7 +27,7 @@ import { useAccount, useChainId, usePublicClient, useSendTransaction, useWalletC
 import { sponsoredContractAddresses } from '../config'
 import { messageToSign } from '../constants'
 import { ERC_1155_SALE_CONTRACT } from '../constants/erc1155-sale-contract'
-import { ERC_721_SALE_CONTRACT } from '../constants/erc721-sale-contract'
+// import { ERC_721_SALE_CONTRACT } from '../constants/erc721-sale-contract'
 import { abi } from '../constants/nft-abi'
 import { delay, getCheckoutSettings, getOrderbookCalldata } from '../utils'
 

--- a/examples/react/src/components/Connected.tsx
+++ b/examples/react/src/components/Connected.tsx
@@ -27,6 +27,7 @@ import { useAccount, useChainId, usePublicClient, useSendTransaction, useWalletC
 import { sponsoredContractAddresses } from '../config'
 import { messageToSign } from '../constants'
 import { ERC_1155_SALE_CONTRACT } from '../constants/erc1155-sale-contract'
+import { ERC_721_SALE_CONTRACT } from '../constants/erc721-sale-contract'
 import { abi } from '../constants/nft-abi'
 import { delay, getCheckoutSettings, getOrderbookCalldata } from '../utils'
 
@@ -363,8 +364,6 @@ export const Connected = () => {
     const price = '200000'
     const contractId = '674eb5613d739107bbd18ed2'
 
-    const chainId = 137
-
     const collectibles = [
       {
         tokenId: '1',
@@ -386,6 +385,28 @@ export const Connected = () => {
         [toHex(0, { size: 32 })]
       ]
     })
+
+    // ERC-721 contract
+    // const currencyAddress = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
+    // const salesContractAddress = '0xa0284905d29cbeb19f4be486f9091fac215b7a6a'
+    // const collectionAddress = '0xd705db0a96075b98758c4bdafe8161d8566a68f8'
+    // const price = '1'
+    // const contractId = '674eb5613d739107bbd18ed2'
+
+    // const chainId = 137
+
+    // const collectibles = [
+    //   {
+    //     quantity: '1'
+    //   }
+    // ]
+
+    // const purchaseTransactionData = encodeFunctionData({
+    //   abi: ERC_721_SALE_CONTRACT,
+    //   functionName: 'mint',
+    //   // [to, amount, expectedPaymentToken, maxTotal, proof]
+    //   args: [address, BigInt(1), currencyAddress, price, [toHex(0, { size: 32 })]]
+    // })
 
     openSelectPaymentModal({
       collectibles,

--- a/examples/react/src/constants/erc721-sale-contract.ts
+++ b/examples/react/src/constants/erc721-sale-contract.ts
@@ -1,0 +1,262 @@
+export const ERC_721_SALE_CONTRACT = [
+  {
+    type: 'function',
+    name: 'DEFAULT_ADMIN_ROLE',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'checkMerkleProof',
+    inputs: [
+      { name: 'root', type: 'bytes32', internalType: 'bytes32' },
+      { name: 'proof', type: 'bytes32[]', internalType: 'bytes32[]' },
+      { name: 'addr', type: 'address', internalType: 'address' },
+      { name: 'salt', type: 'bytes32', internalType: 'bytes32' }
+    ],
+    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'getRoleAdmin',
+    inputs: [{ name: 'role', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [{ name: '', type: 'bytes32', internalType: 'bytes32' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'getRoleMember',
+    inputs: [
+      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
+      { name: 'index', type: 'uint256', internalType: 'uint256' }
+    ],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'getRoleMemberCount',
+    inputs: [{ name: 'role', type: 'bytes32', internalType: 'bytes32' }],
+    outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'grantRole',
+    inputs: [
+      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
+      { name: 'account', type: 'address', internalType: 'address' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'hasRole',
+    inputs: [
+      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
+      { name: 'account', type: 'address', internalType: 'address' }
+    ],
+    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'initialize',
+    inputs: [
+      { name: 'owner', type: 'address', internalType: 'address' },
+      { name: 'items', type: 'address', internalType: 'address' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'itemsContract',
+    inputs: [],
+    outputs: [{ name: '', type: 'address', internalType: 'address' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'mint',
+    inputs: [
+      { name: 'to', type: 'address', internalType: 'address' },
+      { name: 'amount', type: 'uint256', internalType: 'uint256' },
+      { name: 'paymentToken', type: 'address', internalType: 'address' },
+      { name: 'maxTotal', type: 'uint256', internalType: 'uint256' },
+      { name: 'proof', type: 'bytes32[]', internalType: 'bytes32[]' }
+    ],
+    outputs: [],
+    stateMutability: 'payable'
+  },
+  {
+    type: 'function',
+    name: 'renounceRole',
+    inputs: [
+      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
+      { name: 'account', type: 'address', internalType: 'address' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'revokeRole',
+    inputs: [
+      { name: 'role', type: 'bytes32', internalType: 'bytes32' },
+      { name: 'account', type: 'address', internalType: 'address' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'saleDetails',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        internalType: 'struct IERC721SaleFunctions.SaleDetails',
+        components: [
+          { name: 'supplyCap', type: 'uint256', internalType: 'uint256' },
+          { name: 'cost', type: 'uint256', internalType: 'uint256' },
+          { name: 'paymentToken', type: 'address', internalType: 'address' },
+          { name: 'startTime', type: 'uint64', internalType: 'uint64' },
+          { name: 'endTime', type: 'uint64', internalType: 'uint64' },
+          { name: 'merkleRoot', type: 'bytes32', internalType: 'bytes32' }
+        ]
+      }
+    ],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'setSaleDetails',
+    inputs: [
+      { name: 'supplyCap', type: 'uint256', internalType: 'uint256' },
+      { name: 'cost', type: 'uint256', internalType: 'uint256' },
+      { name: 'paymentToken', type: 'address', internalType: 'address' },
+      { name: 'startTime', type: 'uint64', internalType: 'uint64' },
+      { name: 'endTime', type: 'uint64', internalType: 'uint64' },
+      { name: 'merkleRoot', type: 'bytes32', internalType: 'bytes32' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'supportsInterface',
+    inputs: [{ name: 'interfaceId', type: 'bytes4', internalType: 'bytes4' }],
+    outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+    stateMutability: 'view'
+  },
+  {
+    type: 'function',
+    name: 'withdrawERC20',
+    inputs: [
+      { name: 'token', type: 'address', internalType: 'address' },
+      { name: 'to', type: 'address', internalType: 'address' },
+      { name: 'value', type: 'uint256', internalType: 'uint256' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'withdrawETH',
+    inputs: [
+      { name: 'to', type: 'address', internalType: 'address' },
+      { name: 'value', type: 'uint256', internalType: 'uint256' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'event',
+    name: 'ItemsMinted',
+    inputs: [
+      { name: 'to', type: 'address', indexed: false, internalType: 'address' },
+      { name: 'amount', type: 'uint256', indexed: false, internalType: 'uint256' }
+    ],
+    anonymous: false
+  },
+  {
+    type: 'event',
+    name: 'RoleAdminChanged',
+    inputs: [
+      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      { name: 'previousAdminRole', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      { name: 'newAdminRole', type: 'bytes32', indexed: true, internalType: 'bytes32' }
+    ],
+    anonymous: false
+  },
+  {
+    type: 'event',
+    name: 'RoleGranted',
+    inputs: [
+      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      { name: 'account', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'sender', type: 'address', indexed: true, internalType: 'address' }
+    ],
+    anonymous: false
+  },
+  {
+    type: 'event',
+    name: 'RoleRevoked',
+    inputs: [
+      { name: 'role', type: 'bytes32', indexed: true, internalType: 'bytes32' },
+      { name: 'account', type: 'address', indexed: true, internalType: 'address' },
+      { name: 'sender', type: 'address', indexed: true, internalType: 'address' }
+    ],
+    anonymous: false
+  },
+  {
+    type: 'event',
+    name: 'SaleDetailsUpdated',
+    inputs: [
+      { name: 'supplyCap', type: 'uint256', indexed: false, internalType: 'uint256' },
+      { name: 'cost', type: 'uint256', indexed: false, internalType: 'uint256' },
+      { name: 'paymentToken', type: 'address', indexed: false, internalType: 'address' },
+      { name: 'startTime', type: 'uint64', indexed: false, internalType: 'uint64' },
+      { name: 'endTime', type: 'uint64', indexed: false, internalType: 'uint64' },
+      { name: 'merkleRoot', type: 'bytes32', indexed: false, internalType: 'bytes32' }
+    ],
+    anonymous: false
+  },
+  {
+    type: 'error',
+    name: 'InsufficientPayment',
+    inputs: [
+      { name: 'currency', type: 'address', internalType: 'address' },
+      { name: 'expected', type: 'uint256', internalType: 'uint256' },
+      { name: 'actual', type: 'uint256', internalType: 'uint256' }
+    ]
+  },
+  {
+    type: 'error',
+    name: 'InsufficientSupply',
+    inputs: [
+      { name: 'currentSupply', type: 'uint256', internalType: 'uint256' },
+      { name: 'amount', type: 'uint256', internalType: 'uint256' },
+      { name: 'maxSupply', type: 'uint256', internalType: 'uint256' }
+    ]
+  },
+  { type: 'error', name: 'InvalidInitialization', inputs: [] },
+  { type: 'error', name: 'InvalidSaleDetails', inputs: [] },
+  {
+    type: 'error',
+    name: 'MerkleProofInvalid',
+    inputs: [
+      { name: 'root', type: 'bytes32', internalType: 'bytes32' },
+      { name: 'proof', type: 'bytes32[]', internalType: 'bytes32[]' },
+      { name: 'addr', type: 'address', internalType: 'address' },
+      { name: 'salt', type: 'bytes32', internalType: 'bytes32' }
+    ]
+  },
+  { type: 'error', name: 'SaleInactive', inputs: [] },
+  { type: 'error', name: 'WithdrawFailed', inputs: [] }
+]

--- a/packages/checkout/src/contexts/SelectPaymentModal.ts
+++ b/packages/checkout/src/contexts/SelectPaymentModal.ts
@@ -8,7 +8,7 @@ import { createGenericContext } from './genericContext.js'
 export type CreditCardProviders = 'sardine' | 'transak'
 
 export interface Collectible {
-  tokenId: string
+  tokenId?: string
   quantity: string
   decimals?: number
   price?: string

--- a/packages/checkout/src/contexts/TransactionStatusModal.ts
+++ b/packages/checkout/src/contexts/TransactionStatusModal.ts
@@ -1,7 +1,7 @@
 import { createGenericContext } from './genericContext.js'
 
 interface Item {
-  tokenId: string
+  tokenId?: string
   quantity: string
   decimals?: number
   price: string

--- a/packages/checkout/src/hooks/useCheckoutUI/index.tsx
+++ b/packages/checkout/src/hooks/useCheckoutUI/index.tsx
@@ -55,11 +55,16 @@ export const useCheckoutUI = ({
     data: tokenMetadatas,
     isLoading: isLoadingTokenMetadatas,
     error: errorTokenMetadata
-  } = useGetTokenMetadata({
-    chainID: String(chainId),
-    contractAddress: collectionAddress,
-    tokenIDs: [collectible.tokenId]
-  })
+  } = useGetTokenMetadata(
+    {
+      chainID: String(chainId),
+      contractAddress: collectionAddress,
+      tokenIDs: [collectible.tokenId ?? '']
+    },
+    {
+      disabled: !collectible.tokenId
+    }
+  )
 
   const {
     data: dataCollectionInfo,

--- a/packages/checkout/src/hooks/useCheckoutUI/useCreditCardPayment.tsx
+++ b/packages/checkout/src/hooks/useCheckoutUI/useCreditCardPayment.tsx
@@ -106,7 +106,7 @@ export const useCreditCardPayment = ({
         currencySymbol: currencyInfo?.symbol || 'POL',
         currencyDecimals: String(currencyDecimals || 18),
         currencyAddress,
-        nftId: collectible.tokenId,
+        nftId: collectible.tokenId ?? '',
         nftAddress: collectionAddress,
         nftQuantity: collectible.quantity,
         nftDecimals: String(dataCollectionInfo?.decimals || 18),

--- a/packages/checkout/src/hooks/useERC1155SaleContractCheckout.ts
+++ b/packages/checkout/src/hooks/useERC1155SaleContractCheckout.ts
@@ -46,7 +46,7 @@ export const getERC1155SaleContractConfig = ({
     // [to, tokenIds, amounts, data, expectedPaymentToken, maxTotal, proof]
     args: [
       recipientAddress,
-      collectibles.map(c => BigInt(c.tokenId)),
+      collectibles.map(c => BigInt(c.tokenId || '')),
       collectibles.map(c => BigInt(c.quantity)),
       toHex(0),
       currencyAddress,

--- a/packages/checkout/src/views/PaymentSelection/OrderSummary/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/OrderSummary/index.tsx
@@ -12,16 +12,22 @@ export const OrderSummary = () => {
   const network = findSupportedNetwork(chain)
   const chainId = network?.chainId || 137
   const collectionAddress = selectPaymentSettings!.collectionAddress
-  const tokenIds = selectPaymentSettings?.collectibles.map(c => c.tokenId) || []
-  const { data: tokenMetadatas, isLoading: isLoadingTokenMetadatas } = useGetTokenMetadata({
-    chainID: String(chainId),
-    contractAddress: collectionAddress,
-    tokenIDs: tokenIds
-  })
+  const tokenIds = selectPaymentSettings?.collectibles.map(c => c.tokenId || '') || []
+  const { data: tokenMetadatas, isLoading: isLoadingTokenMetadatas } = useGetTokenMetadata(
+    {
+      chainID: String(chainId),
+      contractAddress: collectionAddress,
+      tokenIDs: tokenIds.some(id => id === '') ? [] : tokenIds
+    },
+    {
+      disabled: tokenIds.some(id => id === '')
+    }
+  )
   const { data: dataCollectionInfo, isLoading: isLoadingCollectionInfo } = useGetContractInfo({
     chainID: String(chainId),
     contractAddress: selectPaymentSettings!.collectionAddress
   })
+
   const { data: dataCurrencyInfo, isLoading: isLoadingCurrencyInfo } = useGetContractInfo({
     chainID: String(chainId),
     contractAddress: selectPaymentSettings!.currencyAddress
@@ -33,7 +39,10 @@ export const OrderSummary = () => {
     }
   ])
 
-  const isLoading = isLoadingTokenMetadatas || isLoadingCollectionInfo || isLoadingCurrencyInfo || isLoadingCoinPrices
+  const isTokenIdUnknown = tokenIds.some(id => id === '')
+
+  const isLoading =
+    (isLoadingTokenMetadatas && !isTokenIdUnknown) || isLoadingCollectionInfo || isLoadingCurrencyInfo || isLoadingCoinPrices
 
   if (isLoading) {
     return (
@@ -82,15 +91,23 @@ export const OrderSummary = () => {
                   width: '36px'
                 }}
               >
-                <CollectibleTileImage imageUrl={tokenMetadata?.image} />
+                <CollectibleTileImage
+                  imageUrl={
+                    isTokenIdUnknown
+                      ? dataCollectionInfo?.extensions?.ogImage || dataCollectionInfo?.logoURI
+                      : tokenMetadata?.image
+                  }
+                />
               </div>
               <div className="flex flex-col gap-0.5">
                 <Text variant="small" color="secondary" fontWeight="medium">
                   {dataCollectionInfo?.name || null}
                 </Text>
-                <Text variant="small" color="primary" fontWeight="bold">
-                  {`${tokenMetadata?.name || 'Collectible'} ${collectibleQuantity > 1 ? `x${collectibleQuantity}` : ''}`}
-                </Text>
+                {!isTokenIdUnknown && (
+                  <Text variant="small" color="primary" fontWeight="bold">
+                    {`${tokenMetadata?.name || 'Collectible'} ${collectibleQuantity > 1 ? `x${collectibleQuantity}` : ''}`}
+                  </Text>
+                )}
               </div>
             </div>
           )

--- a/packages/checkout/src/views/PaymentSelection/PayWithCreditCard/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/PayWithCreditCard/index.tsx
@@ -100,7 +100,7 @@ export const PayWithCreditCard = ({ settings, disableButtons, skipOnCloseCallbac
         currencySymbol: currencyInfoData.symbol,
         currencyAddress,
         currencyDecimals: String(currencyInfoData?.decimals || 0),
-        nftId: collectible.tokenId,
+        nftId: collectible.tokenId ?? '',
         nftAddress: collectionAddress,
         nftQuantity: collectible.quantity,
         nftDecimals: collectible.decimals === undefined ? undefined : String(collectible.decimals),

--- a/packages/checkout/src/views/PaymentSelection/index.tsx
+++ b/packages/checkout/src/views/PaymentSelection/index.tsx
@@ -404,6 +404,8 @@ export const PaymentSelectionContent = () => {
     return true
   })
 
+  const isTokenIdUnknown = collectibles.some(collectible => !collectible.tokenId)
+
   return (
     <>
       <div
@@ -429,7 +431,7 @@ export const PaymentSelectionContent = () => {
             />
           </>
         )}
-        {validCreditCardProviders.length > 0 && (
+        {validCreditCardProviders.length > 0 && !isTokenIdUnknown && (
           <>
             <Divider className="w-full my-3" />
             <PayWithCreditCard

--- a/packages/checkout/src/views/TransactionStatus/index.tsx
+++ b/packages/checkout/src/views/TransactionStatus/index.tsx
@@ -87,12 +87,12 @@ export const TransactionStatus = () => {
 
   const [startTime] = useState(new Date())
   const [status, setStatus] = useState<TxStatus>('pending')
-  const noItemsToDisplay = !items || !collectionAddress
+  const noItemsToDisplay = !items || !collectionAddress || items.some(i => i.tokenId === undefined)
   const { data: tokenMetadatas, isLoading: isLoadingTokenMetadatas } = useGetTokenMetadata(
     {
       chainID: String(chainId),
       contractAddress: collectionAddress || '',
-      tokenIDs: items?.map(i => i.tokenId) || []
+      tokenIDs: noItemsToDisplay ? [] : items?.map(i => i.tokenId || '')
     },
     {
       disabled: noItemsToDisplay

--- a/packages/connect/src/styles.ts
+++ b/packages/connect/src/styles.ts
@@ -304,6 +304,9 @@ export const styles = String.raw`
   .my-4 {
     margin-block: calc(var(--spacing) * 4);
   }
+  .mt-0 {
+    margin-top: calc(var(--spacing) * 0);
+  }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
   }
@@ -378,6 +381,9 @@ export const styles = String.raw`
   }
   .inline-flex {
     display: inline-flex;
+  }
+  .table {
+    display: table;
   }
   .aspect-square {
     aspect-ratio: 1 / 1;
@@ -471,6 +477,9 @@ export const styles = String.raw`
   }
   .min-h-full {
     min-height: 100%;
+  }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
   }
   .w-1\/2 {
     width: calc(1/2 * 100%);
@@ -568,11 +577,20 @@ export const styles = String.raw`
   .min-w-full {
     min-width: 100%;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .shrink-0 {
     flex-shrink: 0;
   }
+  .flex-grow {
+    flex-grow: 1;
+  }
   .grow {
     flex-grow: 1;
+  }
+  .border-collapse {
+    border-collapse: collapse;
   }
   .origin-top {
     transform-origin: top;
@@ -954,6 +972,9 @@ export const styles = String.raw`
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
   }
+  .pt-1 {
+    padding-top: calc(var(--spacing) * 1);
+  }
   .pt-1\.5 {
     padding-top: calc(var(--spacing) * 1.5);
   }
@@ -1246,6 +1267,9 @@ export const styles = String.raw`
   .ring-border-normal {
     --tw-ring-color: var(--seq-color-border-normal);
   }
+  .ring-white {
+    --tw-ring-color: var(--color-white);
+  }
   .ring-white\/10 {
     --tw-ring-color: color-mix(in srgb, #fff 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1281,6 +1305,10 @@ export const styles = String.raw`
   }
   .backdrop-blur-xs {
     --tw-backdrop-blur: blur(var(--blur-xs));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }


### PR DESCRIPTION
handle undefined token ids for the purpose of supporting erc-721 sale contracts. The collection image will be used instead if there are not token ids.

![Screenshot from 2025-05-15 17-30-23](https://github.com/user-attachments/assets/7d69d28b-1272-41f9-8160-e65e179c6043)
