### PR TITLE
loading state, tab removed if only 1 option

### DIFF
--- a/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
+++ b/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
@@ -619,6 +619,18 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback }: PayWithCryptoTabProps)
     )
   }
 
+  const getConfirmButtonText = () => {
+    if (isPurchasing) {
+      return 'Confirmation in progress...'
+    }
+
+    if (isFree) {
+      return 'Confirm'
+    }
+
+    return 'Confirm payment'
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <PriceSection />
@@ -633,8 +645,8 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback }: PayWithCryptoTabProps)
         )}
 
         <Button
-          disabled={isPurchasing || isErrorSwapQuote || isError}
-          label={isFree ? 'Confirm' : 'Confirm payment'}
+          disabled={isPurchasing || isErrorSwapQuote}
+          label={getConfirmButtonText()}
           className="w-full"
           shape="square"
           variant="primary"

--- a/packages/checkout/src/views/Checkout/PaymentMethodSelect/index.tsx
+++ b/packages/checkout/src/views/Checkout/PaymentMethodSelect/index.tsx
@@ -59,6 +59,8 @@ export const PaymentSelectionContent = () => {
     ...(showCreditCardPayment ? [{ label: 'Credit Card', value: 'credit-card' as Tab }] : [])
   ]
 
+  const isSingleOption = tabs.length == 1
+
   const TabWrapper = ({ children }: { children: React.ReactNode }) => {
     return <div className="w-full bg-background-secondary mt-2 p-3 rounded-xl min-h-[128px]">{children}</div>
   }
@@ -77,7 +79,7 @@ export const PaymentSelectionContent = () => {
         <div className="w-full relative">
           <div className="absolute top-[50%] left-[50%] -translate-x-1/2 -translate-y-1/2 bg-background-primary px-2">
             <Text variant="xsmall" color="text50" className="relative top-[-2px]" fontWeight="normal">
-              Pay with
+              {`Pay with${isSingleOption ? ' ' + tabs[0].label : ''}`}
             </Text>
           </div>
           <Divider className="w-full" />
@@ -96,7 +98,7 @@ export const PaymentSelectionContent = () => {
             }
           }}
         >
-          <TabsHeader tabs={tabs} value={selectedTab} />
+          {!isSingleOption && <TabsHeader tabs={tabs} value={selectedTab} />}
           <TabsContent value="crypto">
             <TabWrapper>
               <PayWithCryptoTab skipOnCloseCallback={skipOnCloseCallback} />


### PR DESCRIPTION
<!-- PR Title: 2744: Implement Feature XXX / Fix bug in YYY -->

Ticket link: <!-- e.g. https://github.com/0xsequence/issue-tracker/issues/2744 -->

API breaking changes:
- [ ] Yes
- [x] No
<!-- If Yes, explain the diff and migration steps for clients/SDKs here. -->

Manual testing required:
- [ ] Yes
- [x] No
<!-- If Yes, add testing steps here. -->

Docs changes required:
- [ ] Yes
- [x] No
<!-- If yes, add [Link to docs PR](https://github.com/0xsequence/docs/pulls/39). -->

## Description
- added clearer loading state when a transaction is in progress
- removed the tabs in checkout if only a single option is selected
