### PR TITLE
Clear pending confirmation state in useWaasFeeOptions hook.

### DIFF
--- a/packages/connect/src/hooks/useWaasFeeOptions.ts
+++ b/packages/connect/src/hooks/useWaasFeeOptions.ts
@@ -126,6 +126,7 @@ export function useWaasFeeOptions(options?: WaasFeeOptionsConfig): UseWaasFeeOpt
     if (sharedDeferred && sharedPendingConfirmation?.id === id) {
       sharedDeferred.resolve({ id, feeTokenAddress: undefined, confirmed: false })
       sharedDeferred = undefined
+      sharedPendingConfirmation = undefined
       notifyListeners(undefined)
     }
   }

--- a/packages/connect/src/styles.ts
+++ b/packages/connect/src/styles.ts
@@ -2500,4 +2500,6 @@ export const styles = String.raw`
       --tw-gradient-to-position: 100%;
     }
   }
-}`
+}
+
+`


### PR DESCRIPTION
<!-- PR Title: 2744: Implement Feature XXX / Fix bug in YYY -->

Ticket link: <!-- e.g. https://github.com/0xsequence/issue-tracker/issues/2744 -->

API breaking changes:
- [ ] Yes
- [x] No
<!-- If Yes, explain the diff and migration steps for clients/SDKs here. -->

Manual testing required:
- [ ] Yes
- [x] No
<!-- If Yes, add testing steps here. -->

Docs changes required:
- [ ] Yes
- [x] No
<!-- If yes, add [Link to docs PR](https://github.com/0xsequence/docs/pulls/39). -->

## Description
<!-- Add high-level description of the changes introduced in this PR here. -->
After I rejected a pending fee option, the hook’s state reset, but `pendingFeeOptionConfirmation` was still returning fee options. It turns out resetting `sharedPendingConfirmation` was missing.