### PR TITLE
Fix undefined wallet client in checkout

### DIFF
--- a/examples/react/src/config.ts
+++ b/examples/react/src/config.ts
@@ -99,7 +99,8 @@ export const config =
           ChainId.IMMUTABLE_ZKEVM,
           ChainId.IMMUTABLE_ZKEVM_TESTNET,
           ChainId.BASE_SEPOLIA,
-          ChainId.BASE
+          ChainId.BASE,
+          ChainId.SEPOLIA
         ],
         defaultChainId: ChainId.ARBITRUM_NOVA,
         waasConfigKey: isDebugMode

--- a/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
+++ b/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
@@ -69,9 +69,7 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback }: PayWithCryptoTabProps)
   const chainId = network?.chainId || 137
 
   const { address: userAddress, connector } = useAccount()
-  const { data: walletClient } = useWalletClient({
-    chainId: chainId
-  })
+  const { data: walletClient } = useWalletClient()
   const publicClient = usePublicClient({
     chainId: chainId
   })
@@ -189,7 +187,8 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback }: PayWithCryptoTabProps)
 
   const onPurchaseMainCurrency = async () => {
     if (!walletClient || !userAddress || !publicClient || !indexerClient || !connector) {
-      return
+      throw new Error('Wallet client, user address, public client, indexer client, or connector is not found')
+      // TODO: Handle these states better
     }
 
     setIsPurchasing(true)

--- a/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
+++ b/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
@@ -36,7 +36,7 @@ interface PayWithCryptoTabProps {
 
 export const PayWithCryptoTab = ({ skipOnCloseCallback, isSwitchingChainRef }: PayWithCryptoTabProps) => {
   const connectedChainId = useChainId()
-  const { switchChainAsync } = useSwitchChain()
+  const { switchChain } = useSwitchChain()
   const { triggerAddFunds } = useAddFundsModal()
   const { clearCachedBalances } = useClearCachedBalances()
   const [isPurchasing, setIsPurchasing] = useState<boolean>(false)
@@ -145,10 +145,6 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback, isSwitchingChainRef }: P
   )
 
   useEffect(() => {
-    console.log('isSwitchingChainRef.current', isSwitchingChainRef.current)
-    console.log('connectedChainId', connectedChainId)
-    console.log('chainId', chainId)
-    console.log('isLoadingWalletClient', isLoadingWalletClient)
     if (isSwitchingChainRef.current && connectedChainId == Number(chainId) && !isLoadingWalletClient) {
       isSwitchingChainRef.current = false
       onClickPurchase()
@@ -208,8 +204,7 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback, isSwitchingChainRef }: P
 
     try {
       if (connectedChainId != chainId) {
-        // await walletClient.switchChain({ id: chainId })
-        await switchChainAsync({ chainId })
+        await switchChain({ chainId })
         isSwitchingChainRef.current = true
         return
       }
@@ -319,9 +314,8 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback, isSwitchingChainRef }: P
     setIsError(false)
 
     try {
-      const walletClientChainId = await walletClient.getChainId()
-      if (walletClientChainId !== chainId) {
-        await walletClient.switchChain({ id: chainId })
+      if (connectedChainId != chainId) {
+        await switchChain({ chainId })
         isSwitchingChainRef.current = true
         return
       }

--- a/packages/checkout/src/views/Checkout/PaymentMethodSelect/index.tsx
+++ b/packages/checkout/src/views/Checkout/PaymentMethodSelect/index.tsx
@@ -29,6 +29,7 @@ type Tab = 'crypto' | 'credit-card'
 
 export const PaymentSelectionContent = () => {
   const { selectPaymentSettings = {} as SelectPaymentSettings } = useSelectPaymentModal()
+  const isSwitchingChainRef = useRef(false)
 
   const isFirstRender = useRef<boolean>(true)
   const { collectibles, creditCardProviders = [], onClose = () => {}, price } = selectPaymentSettings
@@ -101,7 +102,7 @@ export const PaymentSelectionContent = () => {
           {!isSingleOption && <TabsHeader tabs={tabs} value={selectedTab} />}
           <TabsContent value="crypto">
             <TabWrapper>
-              <PayWithCryptoTab skipOnCloseCallback={skipOnCloseCallback} />
+              <PayWithCryptoTab isSwitchingChainRef={isSwitchingChainRef} skipOnCloseCallback={skipOnCloseCallback} />
             </TabWrapper>
           </TabsContent>
           <TabsContent value="credit-card">

--- a/packages/connect/src/styles.ts
+++ b/packages/connect/src/styles.ts
@@ -2500,6 +2500,4 @@ export const styles = String.raw`
       --tw-gradient-to-position: 100%;
     }
   }
-}
-
-`
+}`


### PR DESCRIPTION
This removes the chainId param from useWalletClient in checkout pay-with-crypto. The chainId param is just a filter and causes the walletClient to be undefined if there is a chain mismatch. The chain switching is handled by a switch chain further down in the code