### PR TITLE
Refactor insufficient balance check in PayWithCrypto component

### DIFF
--- a/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
+++ b/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
@@ -20,7 +20,7 @@ import { TransactionOnRampProvider } from '@0xsequence/marketplace'
 import { findSupportedNetwork } from '@0xsequence/network'
 import { useEffect, useState, type RefObject } from 'react'
 import { encodeFunctionData, formatUnits, zeroAddress, type Hex } from 'viem'
-import { useAccount, useChainId, usePublicClient, useReadContract, useWalletClient, useSwitchChain } from 'wagmi'
+import { useAccount, useChainId, usePublicClient, useReadContract, useSwitchChain, useWalletClient } from 'wagmi'
 
 import { ERC_20_CONTRACT_ABI } from '../../../../constants/abi.js'
 import { EVENT_SOURCE } from '../../../../constants/index.js'
@@ -179,7 +179,8 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback, isSwitchingChainRef }: P
     compareAddress(balance.contractAddress, selectedCurrency.address)
   )
 
-  const isInsufficientBalance = tokenBalance?.balance && BigInt(tokenBalance.balance) < BigInt(selectedCurrencyPrice)
+  const isInsufficientBalance =
+    tokenBalance === undefined || (tokenBalance?.balance && BigInt(tokenBalance.balance) < BigInt(selectedCurrencyPrice))
 
   const isApproved: boolean = (allowanceData as bigint) >= BigInt(price) || isNativeToken
 


### PR DESCRIPTION
* Updated the logic for determining insufficient balance to handle undefined tokenBalance cases.
```
const tokenBalance = tokenBalancesData?.pages?.[0]?.balances?.find(balance =>
    compareAddress(balance.contractAddress, selectedCurrency.address)
  )
  ```
  
 if `tokenBalancesData?.pages?.[0]?.balances` is an empty array, `tokenBalance` goes undefined, we don't check this for `isInsufficientBalance`.

<!-- PR Title: 2744: Implement Feature XXX / Fix bug in YYY -->

Ticket link: https://github.com/0xsequence-demos/fusionpoint-issue-tracker/issues/40

API breaking changes:
- [ ] Yes
- [x] No
<!-- If Yes, explain the diff and migration steps for clients/SDKs here. -->

Manual testing required:
- [ ] Yes
- [x] No
<!-- If Yes, add testing steps here. -->

Docs changes required:
- [ ] Yes
- [x] No
<!-- If yes, add [Link to docs PR](https://github.com/0xsequence/docs/pulls/39). -->

