### PR TITLE
lowercase characters for eth address of the seller and buyer

### DIFF
--- a/packages/checkout/src/api/data.ts
+++ b/packages/checkout/src/api/data.ts
@@ -341,9 +341,9 @@ export const createFortePaymentIntent = async (
     blockchain: forteBlockchainName,
     idempotencyKey: idempotencyKey,
     buyer: {
-      id: recipientAddress,
+      id: recipientAddress.toLowerCase(),
       wallet: {
-        address: recipientAddress,
+        address: recipientAddress.toLowerCase(),
         blockchain: forteBlockchainName
       }
     }
@@ -424,7 +424,7 @@ export const createFortePaymentIntent = async (
       ],
       seller: {
         wallet: {
-          address: protocolConfig.sellerAddress || '',
+          address: protocolConfig.sellerAddress.toLowerCase(),
           blockchain: forteBlockchainName
         }
       }


### PR DESCRIPTION
<!-- PR Title: 2744: Implement Feature XXX / Fix bug in YYY -->

Ticket link: <!-- e.g. https://github.com/0xsequence/issue-tracker/issues/2744 -->

API breaking changes:
- [ ] Yes
- [x] No
<!-- If Yes, explain the diff and migration steps for clients/SDKs here. -->

Manual testing required:
- [ ] Yes
- [x] No
<!-- If Yes, add testing steps here. -->

Docs changes required:
- [ ] Yes
- [x] No
<!-- If yes, add [Link to docs PR](https://github.com/0xsequence/docs/pulls/39). -->

## Description
Turn the wallet addresses to lowercase in for the seller and buyer in a forte transaction