### PR TITLE
disable scientific notation for prices in the transaction status modal

### DIFF
--- a/examples/next/src/app/components/Connected.tsx
+++ b/examples/next/src/app/components/Connected.tsx
@@ -1,4 +1,4 @@
-import type { CheckoutSettings } from '@0xsequence/checkout'
+import { type CheckoutSettings, useTransactionStatusModal } from '@0xsequence/checkout'
 import {
   ContractVerificationStatus,
   signEthAuthProof,

--- a/examples/react/src/components/Connected.tsx
+++ b/examples/react/src/components/Connected.tsx
@@ -5,6 +5,7 @@ import {
   useERC1155SaleContractCheckout,
   useSelectPaymentModal,
   useSwapModal,
+  useTransactionStatusModal,
   type SwapModalSettings
 } from '@0xsequence/checkout'
 import {
@@ -23,7 +24,7 @@ import { useOpenWalletModal } from '@0xsequence/wallet-widget'
 import { CardButton, Header, WalletListItem } from 'example-shared-components'
 import { AnimatePresence } from 'motion/react'
 import React, { useEffect, type ComponentProps } from 'react'
-import { encodeFunctionData, formatUnits, parseAbi } from 'viem'
+import { encodeFunctionData, formatUnits, parseAbi, zeroAddress } from 'viem'
 import { createSiweMessage, generateSiweNonce } from 'viem/siwe'
 import { useAccount, useChainId, usePublicClient, useSendTransaction, useWalletClient, useWriteContract } from 'wagmi'
 
@@ -44,6 +45,7 @@ const onRampProvider = searchParams.get('onRampProvider')
 const checkoutPreset = searchParams.get('checkoutPreset') || 'forte-payment-erc1155-sale-native-token-testnet'
 
 export const Connected = () => {
+  const { openTransactionStatusModal } = useTransactionStatusModal()
   const [isOpenCustomCheckout, setIsOpenCustomCheckout] = React.useState(false)
   const { setOpenConnectModal } = useOpenConnectModal()
   const { address } = useAccount()
@@ -480,6 +482,23 @@ export const Connected = () => {
     setIsSocialLinkOpen(true)
   }
 
+  const onClickTransactionStatus = () => {
+    openTransactionStatusModal({
+      chainId: 137,
+      currencyAddress: zeroAddress,
+      collectionAddress: '0x92473261f2c26f2264429c451f70b0192f858795',
+      txHash: '0x7824a5f7107a964553f799a82d8178fd66ff5055e84f586010ccd80e5e40145b',
+      items: [
+        {
+          tokenId: '1',
+          quantity: '1',
+          decimals: 18,
+          price: '1000'
+        }
+      ]
+    })
+  }
+
   useEffect(() => {
     setLastTxnDataHash(undefined)
     setLastTxnDataHash2(undefined)
@@ -776,6 +795,12 @@ export const Connected = () => {
                   description="Purchase with useERC1155SaleContractCheckout hook"
                   onClick={openCheckoutModal}
                   isPending={erc1155CheckoutLoading}
+                />
+
+                <CardButton
+                  title="Transaction Status Modal"
+                  description="Transaction status modal"
+                  onClick={onClickTransactionStatus}
                 />
               </>
             )}

--- a/packages/checkout/src/views/TransactionStatus/index.tsx
+++ b/packages/checkout/src/views/TransactionStatus/index.tsx
@@ -266,7 +266,9 @@ export const TransactionStatus = () => {
           const collectibleQuantity = Number(formatUnits(BigInt(item.quantity), item?.decimals || 0))
           const tokenMetadata = tokenMetadatas?.find(tokenMetadata => tokenMetadata.tokenId === item.tokenId)
 
-          const price = formatDisplay(formatUnits(BigInt(item.price), dataCurrencyInfo?.decimals || 0))
+          const price = formatDisplay(formatUnits(BigInt(item.price), dataCurrencyInfo?.decimals || 0), {
+            disableScientificNotation: true
+          })
 
           return (
             <div className="flex flex-row items-center justify-between" key={item.tokenId}>

--- a/packages/connect/src/styles.ts
+++ b/packages/connect/src/styles.ts
@@ -2500,6 +2500,4 @@ export const styles = String.raw`
       --tw-gradient-to-position: 100%;
     }
   }
-}
-
-`
+}`


### PR DESCRIPTION
<!-- PR Title: 2744: Implement Feature XXX / Fix bug in YYY -->

Ticket link: <!-- e.g. https://github.com/0xsequence/issue-tracker/issues/2744 -->

API breaking changes:
- [ ] Yes
- [x] No
<!-- If Yes, explain the diff and migration steps for clients/SDKs here. -->

Manual testing required:
- [ ] Yes
- [x] No
<!-- If Yes, add testing steps here. -->

Docs changes required:
- [ ] Yes
- [x] No
<!-- If yes, add [Link to docs PR](https://github.com/0xsequence/docs/pulls/39). -->

## Description
disable scientific notation for prices in transaction status modal
<img width="903" height="461" alt="Screenshot from 2025-10-06 16-38-35" src="https://github.com/user-attachments/assets/3b9fe2ea-aa2d-4f8e-a3cc-a96277f266c7" />

