### PR TITLE
PayWithCryptoTab: if the consumer sends TransactionOnRampProvider.unknown as onRampProvider, the add funds button will be hidden

### DIFF
--- a/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
+++ b/packages/checkout/src/views/Checkout/PaymentMethodSelect/PayWithCrypto/index.tsx
@@ -550,14 +550,16 @@ export const PayWithCryptoTab = ({ skipOnCloseCallback, isSwitchingChainRef }: P
             <TokenSelector />
           </div>
         </div>
-        <Button
-          label="Add Funds"
-          className="w-full"
-          shape="square"
-          variant="glass"
-          leftIcon={() => <AddIcon size="md" />}
-          onClick={onClickAddFunds}
-        ></Button>
+        {onRampProvider !== TransactionOnRampProvider.unknown && (
+          <Button
+            label="Add Funds"
+            className="w-full"
+            shape="square"
+            variant="glass"
+            leftIcon={() => <AddIcon size="md" />}
+            onClick={onClickAddFunds}
+          ></Button>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
# PayWithCryptoTab: 
if the consumer sends TransactionOnRampProvider.unknown as onRampProvider, the add funds button will be hidden

API breaking changes:
- [ ] Yes
- [x] No
<!-- If Yes, explain the diff and migration steps for clients/SDKs here. -->

Manual testing required:
- [x] Yes
- [ ] No
<!-- If Yes, add testing steps here. -->

Docs changes required:
- [ ] Yes
- [x] No
<!-- If yes, add [Link to docs PR](https://github.com/0xsequence/docs/pulls/39). -->
